### PR TITLE
CI: merge target branch before running tests

### DIFF
--- a/.github/scripts/merge-target-branch.sh
+++ b/.github/scripts/merge-target-branch.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Merge specified branch into current branch with proper error handling.
+
+set -euo pipefail
+
+# Accept merge branch as parameter, default to main.
+MERGE_BRANCH="${1:-main}"
+
+echo "=== Merging ${MERGE_BRANCH} into current branch ==="
+
+# Configure git for merge commits.
+git config user.email "actions@github.com"
+git config user.name "GitHub Actions"
+
+# Fetch the latest merge branch.
+echo "Fetching latest ${MERGE_BRANCH} branch..."
+git fetch origin "${MERGE_BRANCH}"
+
+# Show current state for debugging.
+echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "Current commit: $(git rev-parse --short HEAD)"
+echo "${MERGE_BRANCH} commit: $(git rev-parse --short origin/${MERGE_BRANCH})"
+
+# Check if we actually need to merge.
+if git merge-base --is-ancestor "origin/${MERGE_BRANCH}" HEAD; then
+    echo "✓ Current branch is already up to date with ${MERGE_BRANCH}"
+    exit 0
+fi
+
+# Attempt the merge.
+echo "Merging ${MERGE_BRANCH} into current branch..."
+if git merge "origin/${MERGE_BRANCH}" --no-edit --no-ff; then
+    echo "✓ Successfully merged ${MERGE_BRANCH} into current branch"
+
+    # Show merge summary.
+    echo "Merge summary:"
+    git log --oneline --graph -5
+else
+    # Merge failed - check if it's due to conflicts.
+    echo "✗ Merge failed"
+
+    # Show conflict details if any.
+    if git diff --name-only --diff-filter=U | grep -q .; then
+        echo ""
+        echo "Merge conflicts detected in the following files:"
+        git diff --name-only --diff-filter=U
+        echo ""
+        echo "The PR author needs to:"
+        echo "1. Pull the latest ${MERGE_BRANCH} branch"
+        echo "2. Merge or rebase their branch"
+        echo "3. Resolve conflicts"
+        echo "4. Push the updated branch"
+    fi
+
+    # Abort the merge to clean up.
+    git merge --abort 2>/dev/null || true
+    exit 1
+fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,9 +14,6 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: self-hosted
-    defaults:
-      run:
-        working-directory: test-lvgl
 
     steps:
     - name: Checkout code
@@ -24,8 +21,14 @@ jobs:
       with:
         clean: true
         submodules: recursive
+        fetch-depth: 0
+
+    - name: Merge target branch
+      if: github.event_name == 'pull_request'
+      run: .github/scripts/merge-target-branch.sh ${{ github.event.pull_request.base.ref }}
 
     - name: Check code formatting
+      working-directory: test-lvgl
       run: |
         # Check if any files would change after formatting.
         make format
@@ -36,7 +39,9 @@ jobs:
         fi
 
     - name: Build debug version
+      working-directory: test-lvgl
       run: make -j$(nproc) debug
 
     - name: Run unit tests
+      working-directory: test-lvgl
       run: ./build/bin/sparkle-duck-tests


### PR DESCRIPTION
Configure GitHub Actions to automatically merge the target branch (main) into PR branches before running tests. This ensures CI tests the actual post-merge state, catching integration issues early.