### PR TITLE
Remove drain spotlight and tune emissive intensities

### DIFF
--- a/apps/src/core/scenarios/clock_scenario/DrainManager.h
+++ b/apps/src/core/scenarios/clock_scenario/DrainManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "core/LightManager.h"
 #include "core/MaterialType.h"
 #include <chrono>
 #include <cstdint>
@@ -18,7 +17,6 @@ class World;
  * The drain opens in response to water accumulation in the bottom third of the world.
  * Opening size varies (1, 3, 5, 7 cells wide) based on water amount, with hysteresis
  * to prevent rapid flickering. Material in drain cells is sprayed upward and dissipates.
- * A spotlight shines up from the drain when open.
  */
 class DrainManager {
 public:
@@ -40,7 +38,6 @@ private:
     int16_t endX_ = 0;
     int16_t currentSize_ = 0;
     std::chrono::steady_clock::time_point lastSizeChange_{};
-    std::optional<LightHandle> light_;
 
     void updateSize(World& world, double waterAmount);
     void updateCells(
@@ -48,7 +45,6 @@ private:
         double deltaTime,
         std::optional<Material::EnumType> extraMaterial,
         std::mt19937& rng);
-    void updateLight(World& world);
     void applyGravity(World& world);
     void sprayCell(World& world, Cell& cell, int16_t x, int16_t y);
 

--- a/apps/src/core/scenarios/clock_scenario/GlowConfig.h
+++ b/apps/src/core/scenarios/clock_scenario/GlowConfig.h
@@ -9,10 +9,10 @@ namespace DirtSim {
 struct GlowConfig {
     uint32_t digitColor = 0;
     float digitIntensity = 2.0f;
-    float floorIntensity = 0.15f;
-    float obstacleIntensity = 0.6f;
-    float wallIntensity = 0.2f;
-    float waterIntensity = 0.5f;
+    float floorIntensity = 1.0f;
+    float obstacleIntensity = 2.0f;
+    float wallIntensity = 1.0f;
+    float waterIntensity = 1.0f;
 
     using serialize = zpp::bits::members<6>;
 };


### PR DESCRIPTION
## Summary
- Remove the spotlight that shines up from the drain when open (no longer needed with emissive floor/wall glow)
- Increase default glow intensities for floor, obstacles, walls, and water for better visibility

## Test plan
- [ ] Run clock scenario with rain event, verify drain opens without spotlight
- [ ] Verify floor/wall/obstacle glow is visible with new intensity values