### PR TITLE
Fix IconRail auto-minimize bug

### DIFF
--- a/apps/src/ui/UiComponentManager.h
+++ b/apps/src/ui/UiComponentManager.h
@@ -45,30 +45,14 @@ public:
      */
     lv_obj_t* getSimulationContainer();
 
-    /**
-     * @brief Get the icon rail component (simulation screen).
-     */
     IconRail* getIconRail() { return iconRail_.get(); }
-
-    /**
-     * @brief Get the icon rail component (main menu screen).
-     */
-    IconRail* getMenuIconRail() { return menuIconRail_.get(); }
 
     /**
      * @brief Get the content area for main menu (where fractal/buttons go).
      */
     lv_obj_t* getMenuContentArea();
 
-    /**
-     * @brief Get the expandable panel component (simulation screen).
-     */
     ExpandablePanel* getExpandablePanel() { return expandablePanel_.get(); }
-
-    /**
-     * @brief Get the expandable panel component (main menu screen).
-     */
-    ExpandablePanel* getMenuExpandablePanel() { return menuExpandablePanel_.get(); }
 
     /**
      * @brief Get container for world display area (canvas grid).
@@ -163,21 +147,17 @@ private:
     // Current active screen.
     lv_obj_t* currentScreen = nullptr;
 
-    // New icon-based layout components.
-    std::unique_ptr<IconRail> iconRail_;                   // For simulation screen.
-    std::unique_ptr<IconRail> menuIconRail_;               // For main menu screen.
-    std::unique_ptr<ExpandablePanel> expandablePanel_;     // For simulation screen.
-    std::unique_ptr<ExpandablePanel> menuExpandablePanel_; // For main menu screen.
+    // Shared UI components (live on top layer, independent of screens).
+    std::unique_ptr<IconRail> iconRail_;
+    std::unique_ptr<ExpandablePanel> expandablePanel_;
 
     // Simulation screen layout containers.
-    lv_obj_t* simMainRow_ = nullptr;     // Main horizontal row (icon rail + rest).
-    lv_obj_t* simDisplayArea_ = nullptr; // Contains world + neural grid.
+    lv_obj_t* simDisplayArea_ = nullptr;
     lv_obj_t* simWorldDisplayArea_ = nullptr;
     lv_obj_t* simNeuralGridDisplayArea_ = nullptr;
 
     // Main menu screen layout containers.
-    lv_obj_t* menuMainRow_ = nullptr;     // Main horizontal row (icon rail + content).
-    lv_obj_t* menuContentArea_ = nullptr; // Content area (fractal, buttons, etc.).
+    lv_obj_t* menuContentArea_ = nullptr;
 
     bool neuralGridVisible_ = false;
 
@@ -191,10 +171,7 @@ private:
      */
     void cleanupScreen(lv_obj_t*& screen);
 
-    /**
-     * @brief Create the simulation screen layout structure.
-     * Called lazily when first simulation container is requested.
-     */
+    void createSharedComponents();
     void createSimulationLayout();
 
     /**

--- a/apps/src/ui/controls/IconRail.cpp
+++ b/apps/src/ui/controls/IconRail.cpp
@@ -557,7 +557,6 @@ void IconRail::onAutoShrinkTimer(lv_timer_t* timer)
     // Only request shrink if no icon is selected and currently expanded.
     if (self->selectedId_ == IconId::COUNT && self->mode_ == RailMode::Normal) {
         LOG_INFO(Controls, "Auto-shrink timer fired, queueing event");
-        // Queue event for state machine to handle (don't touch LVGL objects from timer).
         if (self->eventSink_) {
             self->eventSink_->queueEvent(RailAutoShrinkRequestEvent{});
         }

--- a/apps/src/ui/state-machine/states/StartMenu.cpp
+++ b/apps/src/ui/state-machine/states/StartMenu.cpp
@@ -66,7 +66,7 @@ void StartMenu::onEnter(StateMachine& sm)
     lv_obj_t* container = uiManager->getMenuContentArea();
 
     // Configure IconRail to show CORE, NETWORK, SCENARIO, and EVOLUTION icons.
-    if (IconRail* iconRail = uiManager->getMenuIconRail()) {
+    if (IconRail* iconRail = uiManager->getIconRail()) {
         iconRail->setVisibleIcons(
             { IconId::CORE, IconId::NETWORK, IconId::SCENARIO, IconId::EVOLUTION });
         LOG_INFO(State, "Configured IconRail with CORE, NETWORK, SCENARIO, and EVOLUTION icons");
@@ -288,7 +288,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
     if (evt.selectedId == IconId::CORE) {
         LOG_INFO(State, "Core icon selected, showing core panel");
 
-        if (auto* panel = uiManager->getMenuExpandablePanel()) {
+        if (auto* panel = uiManager->getExpandablePanel()) {
             panel->clearContent();
             corePanel_ = std::make_unique<StartMenuCorePanel>(panel->getContentArea(), sm);
             panel->show();
@@ -299,7 +299,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
     // Handle deselection of CORE.
     if (evt.previousId == IconId::CORE) {
         LOG_INFO(State, "Core icon deselected, hiding panel");
-        if (auto* panel = uiManager->getMenuExpandablePanel()) {
+        if (auto* panel = uiManager->getExpandablePanel()) {
             panel->hide();
             panel->clearContent();
         }
@@ -310,7 +310,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
     if (evt.selectedId == IconId::NETWORK) {
         LOG_INFO(State, "Network icon selected, showing diagnostics panel");
 
-        if (auto* panel = uiManager->getMenuExpandablePanel()) {
+        if (auto* panel = uiManager->getExpandablePanel()) {
             panel->clearContent();
             networkPanel_ = std::make_unique<NetworkDiagnosticsPanel>(panel->getContentArea());
             panel->show();
@@ -321,7 +321,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
     // Handle deselection of NETWORK.
     if (evt.previousId == IconId::NETWORK) {
         LOG_INFO(State, "Network icon deselected, hiding panel");
-        if (auto* panel = uiManager->getMenuExpandablePanel()) {
+        if (auto* panel = uiManager->getExpandablePanel()) {
             panel->hide();
             panel->clearContent();
         }
@@ -333,7 +333,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
         LOG_INFO(State, "Scenario icon clicked, starting simulation");
         sm.queueEvent(StartButtonClickedEvent{});
         // Deselect action icons after firing.
-        if (auto* iconRail = uiManager->getMenuIconRail()) {
+        if (auto* iconRail = uiManager->getIconRail()) {
             iconRail->deselectAll();
         }
     }
@@ -341,7 +341,7 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
         LOG_INFO(State, "Evolution icon clicked, starting training");
         sm.queueEvent(TrainButtonClickedEvent{});
         // Deselect action icons after firing.
-        if (auto* iconRail = uiManager->getMenuIconRail()) {
+        if (auto* iconRail = uiManager->getIconRail()) {
             iconRail->deselectAll();
         }
     }
@@ -354,7 +354,7 @@ State::Any StartMenu::onEvent(const RailAutoShrinkRequestEvent& /*evt*/, StateMa
     LOG_INFO(State, "Auto-shrink requested, minimizing menu IconRail");
 
     // Process auto-shrink in main thread (safe to modify LVGL objects).
-    if (auto* iconRail = sm.getUiComponentManager()->getMenuIconRail()) {
+    if (auto* iconRail = sm.getUiComponentManager()->getIconRail()) {
         iconRail->setMode(RailMode::Minimized);
     }
 


### PR DESCRIPTION
Fixes a bug where the IconRail would auto-minimize after 10 seconds even when a menu panel was open.

## Root Cause
There were two separate IconRail instances: one for the main menu screen and one for simulation screens (Training/SimRunning). When transitioning from StartMenu to Training, the menuIconRail's auto-shrink timer would keep running and fire 10 seconds later, causing the Training state to minimize its own iconRail.

## Solution
Unified to a single IconRail and ExpandablePanel that live on `lv_layer_top()` and float above all screens. This eliminates the duplicate components and the timer bug.

## Changes
- Removed `menuIconRail_` and `menuExpandablePanel_` from UiComponentManager
- Created shared components on `lv_layer_top()` in `createSharedComponents()`
- Updated all references from `getMenuIconRail()` to `getIconRail()`
- Simplified screen layouts since rail/panel now float above them