### PR TITLE
Gate docker build on iheartci label

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build-docker-image:
     uses: ./.github/workflows/docker-build.yml
+    if: contains(github.event.pull_request.labels.*.name, 'iheartci') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
   build-and-test:
     runs-on: self-hosted


### PR DESCRIPTION
Ensure PR Check doesn't run self-hosted jobs without the iheartci label.