### PR TITLE
Support per-scenario training population

### DIFF
--- a/apps/src/core/organisms/evolution/TrainingRunner.cpp
+++ b/apps/src/core/organisms/evolution/TrainingRunner.cpp
@@ -106,7 +106,7 @@ TrainingRunner::TrainingRunner(
 {
     // Create scenario from registry.
     auto registry = ScenarioRegistry::createDefault(genomeRepository);
-    scenario_ = registry.createScenario(trainingSpec_.scenarioId);
+    scenario_ = registry.createScenario(individual_.scenarioId);
     DIRTSIM_ASSERT(scenario_, "TrainingRunner: Scenario factory returned null");
 
     // Create world with scenario's required dimensions.

--- a/apps/src/core/organisms/evolution/TrainingRunner.h
+++ b/apps/src/core/organisms/evolution/TrainingRunner.h
@@ -51,6 +51,7 @@ public:
 
     struct Individual {
         BrainSpec brain;
+        Scenario::EnumType scenarioId = Scenario::EnumType::TreeGermination;
         std::optional<Genome> genome;
     };
 

--- a/apps/src/core/organisms/evolution/TrainingSpec.h
+++ b/apps/src/core/organisms/evolution/TrainingSpec.h
@@ -17,13 +17,14 @@ namespace DirtSim {
  * Population entry describing one brain kind/variant and its counts.
  */
 struct PopulationSpec {
+    Scenario::EnumType scenarioId = Scenario::EnumType::TreeGermination;
     std::string brainKind;
     std::optional<std::string> brainVariant;
     int count = 0;
     std::vector<GenomeId> seedGenomes;
     int randomCount = 0;
 
-    using serialize = zpp::bits::members<5>;
+    using serialize = zpp::bits::members<6>;
 };
 
 /**

--- a/apps/src/server/states/Evolution.h
+++ b/apps/src/server/states/Evolution.h
@@ -40,6 +40,7 @@ struct Evolution {
     struct Individual {
         std::string brainKind;
         std::optional<std::string> brainVariant;
+        Scenario::EnumType scenarioId = Scenario::EnumType::TreeGermination;
         std::optional<Genome> genome;
         bool allowsMutation = false;
     };
@@ -74,6 +75,7 @@ struct Evolution {
     double evalMaxEnergy_ = 0.0;
     std::optional<TreeResourceTotals> evalTreeResourceTotals_;
     ScenarioConfig evalScenarioConfig_ = Config::Empty{};
+    Scenario::EnumType evalScenarioId_ = Scenario::EnumType::TreeGermination;
 
     // Training timing.
     std::chrono::steady_clock::time_point trainingStartTime_;

--- a/apps/src/ui/TrainingView.h
+++ b/apps/src/ui/TrainingView.h
@@ -75,6 +75,7 @@ public:
     Result<GenomeId, std::string> openGenomeDetailByIndex(int index);
     Result<GenomeId, std::string> openGenomeDetailById(const GenomeId& genomeId);
     Result<std::monostate, std::string> loadGenomeDetail(const GenomeId& genomeId);
+    void addGenomeToTraining(const GenomeId& genomeId, Scenario::EnumType scenarioId);
 
 private:
     bool evolutionStarted_ = false;
@@ -146,6 +147,7 @@ private:
     void renderBestWorld();
     void updateEvolutionVisibility();
     void updateTrainingResultSaveButton();
+    void createGenomeBrowserPanelInternal();
 
     static void onTrainingResultSaveClicked(lv_event_t* e);
     static void onTrainingResultDiscardClicked(lv_event_t* e);

--- a/apps/src/ui/controls/BrowserPanel.h
+++ b/apps/src/ui/controls/BrowserPanel.h
@@ -50,10 +50,17 @@ public:
         {}
     };
 
+    enum class DetailActionColumn {
+        Left,
+        Right,
+    };
+
     struct DetailAction {
         std::string label;
         std::function<Result<std::monostate, std::string>(const Item& item)> handler;
         uint32_t color = 0x00AA66;
+        DetailActionColumn column = DetailActionColumn::Left;
+        bool shareRowWithSidePanel = false;
     };
 
     struct DetailSidePanel {
@@ -77,7 +84,7 @@ public:
         ListFetcher listFetcher,
         DetailFetcher detailFetcher,
         DeleteHandler deleteHandler,
-        std::optional<DetailAction> detailAction = std::nullopt,
+        std::vector<DetailAction> detailActions = {},
         std::optional<DetailSidePanel> detailSidePanel = std::nullopt,
         std::optional<ListActionPanel> listActionPanel = std::nullopt,
         ModalStyle modalStyle = ModalStyle{});
@@ -90,6 +97,11 @@ public:
 
 private:
     struct CallbackContext {
+        BrowserPanel* panel = nullptr;
+        size_t index = 0;
+    };
+
+    struct ModalActionContext {
         BrowserPanel* panel = nullptr;
         size_t index = 0;
     };
@@ -109,7 +121,6 @@ private:
     lv_obj_t* modalDeleteButton_ = nullptr;
     lv_obj_t* modalOverlay_ = nullptr;
     lv_obj_t* selectAllButton_ = nullptr;
-    lv_obj_t* modalActionButton_ = nullptr;
     lv_obj_t* modalSideColumn_ = nullptr;
     lv_obj_t* modalSideContent_ = nullptr;
     lv_obj_t* modalToggleButton_ = nullptr;
@@ -118,6 +129,7 @@ private:
     std::vector<Item> items_;
     std::vector<RowWidgets> rows_;
     std::vector<std::unique_ptr<CallbackContext>> rowContexts_;
+    std::vector<std::unique_ptr<ModalActionContext>> modalActionContexts_;
     std::unordered_set<GenomeId> selectedIds_;
     std::optional<GenomeId> modalItemId_;
     bool sidePanelVisible_ = false;
@@ -125,7 +137,7 @@ private:
     ListFetcher listFetcher_;
     DetailFetcher detailFetcher_;
     DeleteHandler deleteHandler_;
-    std::optional<DetailAction> detailAction_;
+    std::vector<DetailAction> detailActions_;
     std::optional<DetailSidePanel> detailSidePanel_;
     std::optional<ListActionPanel> listActionPanel_;
     ModalStyle modalStyle_{};
@@ -137,6 +149,7 @@ private:
     void updateSelectionCheckboxes();
     void openDetailModal(size_t index);
     void closeModal();
+    void handleModalAction(size_t index);
 
     bool isDeleteConfirmChecked() const;
     bool isModalDeleteConfirmChecked() const;

--- a/apps/src/ui/controls/EvolutionConfigPanel.cpp
+++ b/apps/src/ui/controls/EvolutionConfigPanel.cpp
@@ -286,6 +286,7 @@ void EvolutionConfigPanel::onPopulationChanged(lv_event_t* e)
             return;
         }
         PopulationSpec entry;
+        entry.scenarioId = spec.scenarioId;
         switch (spec.organismType) {
             case OrganismType::TREE:
                 entry.brainKind = TrainingBrainKind::NeuralNet;

--- a/apps/src/ui/controls/GenomeBrowserPanel.h
+++ b/apps/src/ui/controls/GenomeBrowserPanel.h
@@ -66,6 +66,7 @@ private:
     Result<BrowserPanel::DetailText, std::string> fetchDetail(const BrowserPanel::Item& item);
     Result<bool, std::string> deleteItem(const BrowserPanel::Item& item);
     Result<std::monostate, std::string> loadItem(const BrowserPanel::Item& item);
+    Result<std::monostate, std::string> addItemToTraining(const BrowserPanel::Item& item);
     void buildSortControls(lv_obj_t* parent);
     void buildScenarioPanel(lv_obj_t* parent, const BrowserPanel::Item& item);
     void clearScenarioPanelState();

--- a/apps/src/ui/controls/TrainingConfigPanel.h
+++ b/apps/src/ui/controls/TrainingConfigPanel.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include "core/organisms/evolution/EvolutionConfig.h"
+#include "core/organisms/evolution/GenomeMetadata.h"
 #include "lvgl/lvgl.h"
 #include <memory>
 
 namespace DirtSim {
 
 struct TrainingSpec;
+namespace Network {
+class WebSocketServiceInterface;
+}
 
 namespace Ui {
 
@@ -26,6 +30,7 @@ public:
         lv_obj_t* container,
         EventSink& eventSink,
         ExpandablePanel* panel,
+        Network::WebSocketServiceInterface* wsService,
         bool evolutionStarted,
         EvolutionConfig& evolutionConfig,
         MutationConfig& mutationConfig,
@@ -35,11 +40,13 @@ public:
     void setEvolutionStarted(bool started);
     void setEvolutionCompleted();
     void showView(View view);
+    void addSeedGenome(const GenomeId& genomeId, Scenario::EnumType scenarioId);
 
 private:
     lv_obj_t* container_ = nullptr;
     EventSink& eventSink_;
     ExpandablePanel* panel_ = nullptr;
+    Network::WebSocketServiceInterface* wsService_ = nullptr;
 
     bool evolutionStarted_ = false;
     bool evolutionCompleted_ = false;

--- a/apps/src/ui/controls/TrainingPopulationPanel.cpp
+++ b/apps/src/ui/controls/TrainingPopulationPanel.cpp
@@ -1,19 +1,30 @@
 #include "TrainingPopulationPanel.h"
+#include "core/network/WebSocketServiceInterface.h"
 #include "core/organisms/evolution/EvolutionConfig.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/reflect.h"
+#include "server/api/GenomeGet.h"
 #include "ui/state-machine/EventSink.h"
 #include "ui/ui_builders/LVGLBuilder.h"
 #include <algorithm>
+#include <iomanip>
 #include <spdlog/spdlog.h>
+#include <sstream>
 
 namespace DirtSim {
 namespace Ui {
 
 namespace {
-constexpr int kPopulationMin = 10;
-constexpr int kPopulationMax = 200;
-constexpr int kPopulationStep = 10;
+constexpr int kAddCountMin = 1;
+constexpr int kAddCountMax = 9999;
+constexpr int kAddCountStep = 1;
+constexpr int kColumnGap = 12;
+constexpr int kListColumnWidthPercent = 55;
+constexpr int kMainColumnWidthPercent = 45;
+constexpr int kScenarioColumnWidthPercent = 55;
+constexpr int kEntryRowHeight = 60;
+constexpr int kListHeight = 240;
 
 std::vector<TrainingPopulationPanel::BrainOption> getBrainOptions(OrganismType organismType)
 {
@@ -53,55 +64,6 @@ const char* organismLabel(OrganismType organismType)
     }
 }
 
-void applyCounts(PopulationSpec& spec, int count, bool requiresGenome)
-{
-    spec.count = count;
-    if (!requiresGenome) {
-        spec.seedGenomes.clear();
-        spec.randomCount = 0;
-        return;
-    }
-
-    if (static_cast<int>(spec.seedGenomes.size()) > spec.count) {
-        spec.seedGenomes.resize(spec.count);
-    }
-    spec.randomCount = spec.count - static_cast<int>(spec.seedGenomes.size());
-}
-
-bool requiresGenome(
-    const std::vector<TrainingPopulationPanel::BrainOption>& options, const std::string& kind)
-{
-    for (const auto& option : options) {
-        if (option.kind == kind) {
-            return option.requiresGenome;
-        }
-    }
-    return false;
-}
-
-void clampCounts(int& countA, int& countB)
-{
-    countA = std::max(kPopulationStep, countA);
-    countB = std::max(0, countB);
-
-    int total = countA + countB;
-    if (total > kPopulationMax) {
-        int excess = total - kPopulationMax;
-        if (countB >= excess) {
-            countB -= excess;
-        }
-        else {
-            countA = std::max(kPopulationStep, countA - (excess - countB));
-            countB = 0;
-        }
-    }
-
-    total = countA + countB;
-    if (total < kPopulationMin) {
-        countA = std::max(kPopulationStep, kPopulationMin - countB);
-    }
-}
-
 lv_obj_t* getActionButtonLabel(lv_obj_t* container)
 {
     if (!container) {
@@ -130,11 +92,13 @@ void setActionButtonText(lv_obj_t* container, const std::string& text)
 TrainingPopulationPanel::TrainingPopulationPanel(
     lv_obj_t* container,
     EventSink& eventSink,
+    Network::WebSocketServiceInterface* wsService,
     bool evolutionStarted,
     EvolutionConfig& evolutionConfig,
     TrainingSpec& trainingSpec)
     : container_(container),
       eventSink_(eventSink),
+      wsService_(wsService),
       evolutionStarted_(evolutionStarted),
       evolutionConfig_(evolutionConfig),
       trainingSpec_(trainingSpec)
@@ -156,27 +120,9 @@ TrainingPopulationPanel::TrainingPopulationPanel(
 
     selectedScenario_ = trainingSpec_.scenarioId;
     selectedOrganism_ = trainingSpec_.organismType;
-    brainOptions_ = getBrainOptions(selectedOrganism_);
+    setBrainOptionsForOrganism(selectedOrganism_);
 
-    viewController_ = std::make_unique<PanelViewController>(container_);
-    lv_obj_t* mainView = viewController_->createView("main");
-    createMainView(mainView);
-
-    lv_obj_t* scenarioView = viewController_->createView("scenario_select");
-    createScenarioSelectView(scenarioView);
-
-    lv_obj_t* organismView = viewController_->createView("organism_select");
-    createOrganismSelectView(organismView);
-
-    lv_obj_t* brainAView = viewController_->createView("brain_a_select");
-    createBrainSelectView(
-        brainAView, "Brain Type A", false, brainAButtonToValue_, onBrainASelected);
-
-    lv_obj_t* brainBView = viewController_->createView("brain_b_select");
-    createBrainSelectView(brainBView, "Brain Type B", true, brainBButtonToValue_, onBrainBSelected);
-
-    viewController_->showView("main");
-
+    createLayout();
     refreshFromSpec();
 
     spdlog::info("TrainingPopulationPanel: Initialized (started={})", evolutionStarted_);
@@ -184,29 +130,87 @@ TrainingPopulationPanel::TrainingPopulationPanel(
 
 TrainingPopulationPanel::~TrainingPopulationPanel()
 {
+    closeDetailModal();
     spdlog::info("TrainingPopulationPanel: Destroyed");
 }
 
-void TrainingPopulationPanel::createMainView(lv_obj_t* view)
+void TrainingPopulationPanel::createLayout()
 {
-    lv_obj_t* titleLabel = lv_label_create(view);
+    lv_obj_t* columns = lv_obj_create(container_);
+    lv_obj_set_size(columns, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(columns, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(columns, 0, 0);
+    lv_obj_set_style_pad_all(columns, 0, 0);
+    lv_obj_set_style_pad_column(columns, kColumnGap, 0);
+    lv_obj_set_style_pad_row(columns, 0, 0);
+    lv_obj_set_flex_flow(columns, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(columns, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(columns, LV_OBJ_FLAG_SCROLLABLE);
+
+    mainColumn_ = lv_obj_create(columns);
+    lv_obj_set_width(mainColumn_, LV_PCT(100));
+    lv_obj_set_height(mainColumn_, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(mainColumn_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(mainColumn_, 0, 0);
+    lv_obj_set_style_pad_all(mainColumn_, 0, 0);
+    lv_obj_set_style_pad_row(mainColumn_, 6, 0);
+    lv_obj_set_flex_flow(mainColumn_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        mainColumn_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(mainColumn_, LV_OBJ_FLAG_SCROLLABLE);
+
+    listColumn_ = lv_obj_create(columns);
+    lv_obj_set_width(listColumn_, LV_PCT(kListColumnWidthPercent));
+    lv_obj_set_height(listColumn_, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(listColumn_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(listColumn_, 0, 0);
+    lv_obj_set_style_pad_all(listColumn_, 0, 0);
+    lv_obj_set_style_pad_row(listColumn_, 6, 0);
+    lv_obj_set_flex_flow(listColumn_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        listColumn_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(listColumn_, LV_OBJ_FLAG_SCROLLABLE);
+
+    scenarioColumn_ = lv_obj_create(columns);
+    lv_obj_set_width(scenarioColumn_, LV_PCT(kScenarioColumnWidthPercent));
+    lv_obj_set_height(scenarioColumn_, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(scenarioColumn_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(scenarioColumn_, 0, 0);
+    lv_obj_set_style_pad_all(scenarioColumn_, 0, 0);
+    lv_obj_set_style_pad_row(scenarioColumn_, 6, 0);
+    lv_obj_set_flex_flow(scenarioColumn_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        scenarioColumn_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(scenarioColumn_, LV_OBJ_FLAG_SCROLLABLE);
+
+    createMainColumn(mainColumn_);
+    createListColumn(listColumn_);
+    createScenarioColumn(scenarioColumn_);
+
+    setScenarioColumnVisible(false);
+}
+
+void TrainingPopulationPanel::createMainColumn(lv_obj_t* parent)
+{
+    lv_obj_t* titleLabel = lv_label_create(parent);
     lv_label_set_text(titleLabel, "Population Setup");
     lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xDA70D6), 0);
     lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
     lv_obj_set_style_pad_top(titleLabel, 8, 0);
     lv_obj_set_style_pad_bottom(titleLabel, 8, 0);
 
-    lv_obj_t* column = lv_obj_create(view);
-    lv_obj_set_size(column, LV_PCT(100), LV_SIZE_CONTENT);
-    lv_obj_set_style_bg_opa(column, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(column, 0, 0);
-    lv_obj_set_style_pad_all(column, 0, 0);
-    lv_obj_set_style_pad_row(column, 6, 0);
-    lv_obj_set_flex_flow(column, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(column, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-    lv_obj_clear_flag(column, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_t* scenarioRow = lv_obj_create(parent);
+    lv_obj_set_size(scenarioRow, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(scenarioRow, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(scenarioRow, 0, 0);
+    lv_obj_set_style_pad_all(scenarioRow, 0, 0);
+    lv_obj_set_style_pad_column(scenarioRow, 6, 0);
+    lv_obj_set_flex_flow(scenarioRow, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(
+        scenarioRow, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(scenarioRow, LV_OBJ_FLAG_SCROLLABLE);
 
-    scenarioButton_ = LVGLBuilder::actionButton(column)
+    scenarioButton_ = LVGLBuilder::actionButton(scenarioRow)
                           .text("Scenario: --")
                           .icon(LV_SYMBOL_RIGHT)
                           .width(LV_PCT(95))
@@ -216,7 +220,18 @@ void TrainingPopulationPanel::createMainView(lv_obj_t* view)
                           .callback(onScenarioButtonClicked, this)
                           .buildOrLog();
 
-    organismButton_ = LVGLBuilder::actionButton(column)
+    lv_obj_t* organismRow = lv_obj_create(parent);
+    lv_obj_set_size(organismRow, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(organismRow, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(organismRow, 0, 0);
+    lv_obj_set_style_pad_all(organismRow, 0, 0);
+    lv_obj_set_style_pad_column(organismRow, 6, 0);
+    lv_obj_set_flex_flow(organismRow, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(
+        organismRow, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(organismRow, LV_OBJ_FLAG_SCROLLABLE);
+
+    organismButton_ = LVGLBuilder::actionButton(organismRow)
                           .text("Organism Type: --")
                           .icon(LV_SYMBOL_RIGHT)
                           .width(LV_PCT(95))
@@ -226,28 +241,64 @@ void TrainingPopulationPanel::createMainView(lv_obj_t* view)
                           .callback(onOrganismButtonClicked, this)
                           .buildOrLog();
 
-    brainAButton_ = LVGLBuilder::actionButton(column)
-                        .text("Brain Type A: --")
-                        .icon(LV_SYMBOL_RIGHT)
-                        .width(LV_PCT(95))
-                        .height(LVGLBuilder::Style::ACTION_SIZE)
-                        .layoutRow()
-                        .alignLeft()
-                        .callback(onBrainAButtonClicked, this)
-                        .buildOrLog();
+    organismList_ = lv_obj_create(parent);
+    lv_obj_set_width(organismList_, LV_PCT(95));
+    lv_obj_set_style_bg_opa(organismList_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(organismList_, 0, 0);
+    lv_obj_set_style_pad_all(organismList_, 0, 0);
+    lv_obj_set_style_pad_row(organismList_, 6, 0);
+    lv_obj_set_flex_flow(organismList_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        organismList_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(organismList_, LV_OBJ_FLAG_SCROLLABLE);
 
-    brainBButton_ = LVGLBuilder::actionButton(column)
-                        .text("Brain Type B: None")
-                        .icon(LV_SYMBOL_RIGHT)
-                        .width(LV_PCT(95))
-                        .height(LVGLBuilder::Style::ACTION_SIZE)
-                        .layoutRow()
-                        .alignLeft()
-                        .callback(onBrainBButtonClicked, this)
-                        .buildOrLog();
+    organismButtonToValue_.clear();
+    for (size_t i = 0; i < organismOptions_.size(); ++i) {
+        const std::string& label = organismLabels_[i];
+        lv_obj_t* container = LVGLBuilder::actionButton(organismList_)
+                                  .text(label.c_str())
+                                  .width(LV_PCT(100))
+                                  .height(LVGLBuilder::Style::ACTION_SIZE)
+                                  .layoutColumn()
+                                  .buildOrLog();
+        if (container) {
+            lv_obj_t* button = lv_obj_get_child(container, 0);
+            if (button) {
+                organismButtonToValue_[button] = organismOptions_[i];
+                lv_obj_add_event_cb(button, onOrganismSelected, LV_EVENT_CLICKED, this);
+            }
+        }
+    }
 
-    totalCountLabel_ = lv_label_create(column);
+    setOrganismListVisible(false);
+
+    addCountStepper_ = LVGLBuilder::actionStepper(parent)
+                           .label("Add Count")
+                           .range(kAddCountMin, kAddCountMax)
+                           .step(kAddCountStep)
+                           .value(addCount_)
+                           .valueFormat("%.0f")
+                           .valueScale(1.0)
+                           .width(LV_PCT(95))
+                           .callback(onAddCountChanged, this)
+                           .buildOrLog();
+
+    addButton_ = LVGLBuilder::actionButton(parent)
+                     .text("Add")
+                     .width(LV_PCT(95))
+                     .height(LVGLBuilder::Style::ACTION_SIZE)
+                     .backgroundColor(0x00AA66)
+                     .layoutRow()
+                     .alignLeft()
+                     .callback(onAddClicked, this)
+                     .buildOrLog();
+}
+
+void TrainingPopulationPanel::createListColumn(lv_obj_t* parent)
+{
+    totalCountLabel_ = lv_label_create(parent);
     lv_label_set_text(totalCountLabel_, "Total: --");
+    lv_label_set_long_mode(totalCountLabel_, LV_LABEL_LONG_WRAP);
     lv_obj_set_width(totalCountLabel_, LV_PCT(95));
     lv_obj_set_style_text_align(totalCountLabel_, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_style_text_color(totalCountLabel_, lv_color_white(), 0);
@@ -255,43 +306,73 @@ void TrainingPopulationPanel::createMainView(lv_obj_t* view)
     lv_obj_set_style_pad_top(totalCountLabel_, 2, 0);
     lv_obj_set_style_pad_bottom(totalCountLabel_, 4, 0);
 
-    countAStepper_ = LVGLBuilder::actionStepper(column)
-                         .label("Count A")
-                         .range(kPopulationMin, kPopulationMax)
-                         .step(kPopulationStep)
-                         .value(evolutionConfig_.populationSize)
-                         .valueFormat("%.0f")
-                         .valueScale(1.0)
-                         .width(LV_PCT(95))
-                         .callback(onCountAChanged, this)
-                         .buildOrLog();
-    countBStepper_ = LVGLBuilder::actionStepper(column)
-                         .label("Count B")
-                         .range(0, kPopulationMax)
-                         .step(kPopulationStep)
-                         .value(0)
-                         .valueFormat("%.0f")
-                         .valueScale(1.0)
-                         .width(LV_PCT(95))
-                         .callback(onCountBChanged, this)
-                         .buildOrLog();
+    lv_obj_t* listLabel = lv_label_create(parent);
+    lv_label_set_text(listLabel, "Population List");
+    lv_obj_set_style_text_color(listLabel, lv_color_hex(0xCCCCCC), 0);
+    lv_obj_set_style_text_font(listLabel, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_pad_top(listLabel, 6, 0);
+    lv_obj_set_style_pad_bottom(listLabel, 4, 0);
 
-    updateControlsEnabled();
+    populationList_ = lv_obj_create(parent);
+    lv_obj_set_width(populationList_, LV_PCT(95));
+    lv_obj_set_height(populationList_, kListHeight);
+    lv_obj_set_style_bg_opa(populationList_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(populationList_, 0, 0);
+    lv_obj_set_style_pad_all(populationList_, 0, 0);
+    lv_obj_set_style_pad_row(populationList_, 6, 0);
+    lv_obj_set_flex_flow(populationList_, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        populationList_, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_scroll_dir(populationList_, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(populationList_, LV_SCROLLBAR_MODE_AUTO);
+
+    lv_obj_t* clearRow = lv_obj_create(parent);
+    lv_obj_set_size(clearRow, LV_PCT(95), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(clearRow, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(clearRow, 0, 0);
+    lv_obj_set_style_pad_all(clearRow, 0, 0);
+    lv_obj_set_style_pad_column(clearRow, 6, 0);
+    lv_obj_set_flex_flow(clearRow, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(
+        clearRow, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(clearRow, LV_OBJ_FLAG_SCROLLABLE);
+
+    clearAllButton_ = LVGLBuilder::actionButton(clearRow)
+                          .text("Clear All")
+                          .mode(LVGLBuilder::ActionMode::Push)
+                          .height(LVGLBuilder::Style::ACTION_SIZE)
+                          .width(120)
+                          .layoutRow()
+                          .alignLeft()
+                          .backgroundColor(0xCC0000)
+                          .callback(onClearAllClicked, this)
+                          .buildOrLog();
+
+    clearAllConfirmCheckbox_ = lv_checkbox_create(clearRow);
+    lv_checkbox_set_text(clearAllConfirmCheckbox_, "Confirm");
+    lv_obj_set_style_text_font(clearAllConfirmCheckbox_, &lv_font_montserrat_12, 0);
+    lv_obj_add_event_cb(
+        clearAllConfirmCheckbox_, onClearAllConfirmToggled, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_clear_flag(clearAllConfirmCheckbox_, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_opa(clearAllConfirmCheckbox_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(clearAllConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_all(clearAllConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_column(clearAllConfirmCheckbox_, 8, 0);
 }
 
-void TrainingPopulationPanel::createScenarioSelectView(lv_obj_t* view)
+void TrainingPopulationPanel::createScenarioColumn(lv_obj_t* parent)
 {
-    LVGLBuilder::actionButton(view)
+    LVGLBuilder::actionButton(parent)
         .text("Back")
         .icon(LV_SYMBOL_LEFT)
         .width(LV_PCT(95))
         .height(LVGLBuilder::Style::ACTION_SIZE)
         .layoutRow()
         .alignLeft()
-        .callback(onSelectionBackClicked, this)
+        .callback(onScenarioBackClicked, this)
         .buildOrLog();
 
-    lv_obj_t* titleLabel = lv_label_create(view);
+    lv_obj_t* titleLabel = lv_label_create(parent);
     lv_label_set_text(titleLabel, "Scenario");
     lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFFFFF), 0);
     lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
@@ -301,7 +382,7 @@ void TrainingPopulationPanel::createScenarioSelectView(lv_obj_t* view)
     scenarioButtonToValue_.clear();
     for (size_t i = 0; i < scenarioOptions_.size(); ++i) {
         const std::string& label = scenarioLabels_[i];
-        lv_obj_t* container = LVGLBuilder::actionButton(view)
+        lv_obj_t* container = LVGLBuilder::actionButton(parent)
                                   .text(label.c_str())
                                   .width(LV_PCT(95))
                                   .height(LVGLBuilder::Style::ACTION_SIZE)
@@ -317,125 +398,85 @@ void TrainingPopulationPanel::createScenarioSelectView(lv_obj_t* view)
     }
 }
 
-void TrainingPopulationPanel::createOrganismSelectView(lv_obj_t* view)
+void TrainingPopulationPanel::setScenarioColumnVisible(bool visible)
 {
-    LVGLBuilder::actionButton(view)
-        .text("Back")
-        .icon(LV_SYMBOL_LEFT)
-        .width(LV_PCT(95))
-        .height(LVGLBuilder::Style::ACTION_SIZE)
-        .layoutRow()
-        .alignLeft()
-        .callback(onSelectionBackClicked, this)
-        .buildOrLog();
+    scenarioColumnVisible_ = visible;
+    if (!scenarioColumn_) {
+        return;
+    }
 
-    lv_obj_t* titleLabel = lv_label_create(view);
-    lv_label_set_text(titleLabel, "Organism Type");
-    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFFFFF), 0);
-    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
-    lv_obj_set_style_pad_top(titleLabel, 8, 0);
-    lv_obj_set_style_pad_bottom(titleLabel, 4, 0);
-
-    organismButtonToValue_.clear();
-    for (size_t i = 0; i < organismOptions_.size(); ++i) {
-        const std::string& label = organismLabels_[i];
-        lv_obj_t* container = LVGLBuilder::actionButton(view)
-                                  .text(label.c_str())
-                                  .width(LV_PCT(95))
-                                  .height(LVGLBuilder::Style::ACTION_SIZE)
-                                  .layoutColumn()
-                                  .buildOrLog();
-        if (container) {
-            lv_obj_t* button = lv_obj_get_child(container, 0);
-            if (button) {
-                organismButtonToValue_[button] = organismOptions_[i];
-                lv_obj_add_event_cb(button, onOrganismSelected, LV_EVENT_CLICKED, this);
-            }
+    if (visible) {
+        lv_obj_clear_flag(scenarioColumn_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(scenarioColumn_, LV_OBJ_FLAG_IGNORE_LAYOUT);
+        if (listColumn_) {
+            lv_obj_add_flag(listColumn_, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(listColumn_, LV_OBJ_FLAG_IGNORE_LAYOUT);
+        }
+        if (mainColumn_) {
+            lv_obj_set_width(mainColumn_, LV_PCT(kMainColumnWidthPercent));
+        }
+        lv_obj_set_width(scenarioColumn_, LV_PCT(kScenarioColumnWidthPercent));
+    }
+    else {
+        lv_obj_add_flag(scenarioColumn_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(scenarioColumn_, LV_OBJ_FLAG_IGNORE_LAYOUT);
+        if (listColumn_) {
+            lv_obj_clear_flag(listColumn_, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(listColumn_, LV_OBJ_FLAG_IGNORE_LAYOUT);
+            lv_obj_set_width(listColumn_, LV_PCT(kListColumnWidthPercent));
+        }
+        if (mainColumn_) {
+            lv_obj_set_width(mainColumn_, LV_PCT(kMainColumnWidthPercent));
         }
     }
 }
 
-void TrainingPopulationPanel::createBrainSelectView(
-    lv_obj_t* view,
-    const char* title,
-    bool includeNone,
-    std::unordered_map<lv_obj_t*, std::string>& buttonMap,
-    lv_event_cb_t callback)
+void TrainingPopulationPanel::setOrganismListVisible(bool visible)
 {
-    lv_obj_clean(view);
-
-    LVGLBuilder::actionButton(view)
-        .text("Back")
-        .icon(LV_SYMBOL_LEFT)
-        .width(LV_PCT(95))
-        .height(LVGLBuilder::Style::ACTION_SIZE)
-        .layoutRow()
-        .alignLeft()
-        .callback(onSelectionBackClicked, this)
-        .buildOrLog();
-
-    lv_obj_t* titleLabel = lv_label_create(view);
-    lv_label_set_text(titleLabel, title);
-    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFFFFF), 0);
-    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
-    lv_obj_set_style_pad_top(titleLabel, 8, 0);
-    lv_obj_set_style_pad_bottom(titleLabel, 4, 0);
-
-    buttonMap.clear();
-    if (includeNone) {
-        lv_obj_t* container = LVGLBuilder::actionButton(view)
-                                  .text("None")
-                                  .width(LV_PCT(95))
-                                  .height(LVGLBuilder::Style::ACTION_SIZE)
-                                  .layoutColumn()
-                                  .buildOrLog();
-        if (container) {
-            lv_obj_t* button = lv_obj_get_child(container, 0);
-            if (button) {
-                buttonMap[button] = "";
-                lv_obj_add_event_cb(button, callback, LV_EVENT_CLICKED, this);
-            }
-        }
+    organismListVisible_ = visible;
+    if (!organismList_) {
+        return;
     }
 
-    for (const auto& option : brainOptions_) {
-        lv_obj_t* container = LVGLBuilder::actionButton(view)
-                                  .text(option.kind.c_str())
-                                  .width(LV_PCT(95))
-                                  .height(LVGLBuilder::Style::ACTION_SIZE)
-                                  .layoutColumn()
-                                  .buildOrLog();
-        if (container) {
-            lv_obj_t* button = lv_obj_get_child(container, 0);
-            if (button) {
-                buttonMap[button] = option.kind;
-                lv_obj_add_event_cb(button, callback, LV_EVENT_CLICKED, this);
-            }
-        }
+    if (visible) {
+        lv_obj_clear_flag(organismList_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(organismList_, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    }
+    else {
+        lv_obj_add_flag(organismList_, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(organismList_, LV_OBJ_FLAG_IGNORE_LAYOUT);
     }
 }
 
 void TrainingPopulationPanel::updateControlsEnabled()
 {
-    auto setEnabled = [](lv_obj_t* control, bool enabled) {
-        if (!control) return;
-        if (enabled) {
-            lv_obj_clear_state(control, LV_STATE_DISABLED);
-            lv_obj_set_style_opa(control, LV_OPA_COVER, 0);
-        }
-        else {
-            lv_obj_add_state(control, LV_STATE_DISABLED);
-            lv_obj_set_style_opa(control, LV_OPA_50, 0);
-        }
-    };
-
     const bool enabled = !evolutionStarted_;
-    setEnabled(scenarioButton_, enabled);
-    setEnabled(organismButton_, enabled);
-    setEnabled(brainAButton_, enabled);
-    setEnabled(brainBButton_, enabled);
-    setEnabled(countAStepper_, enabled);
-    setEnabled(countBStepper_, enabled && !brainB_.empty());
+    setControlEnabled(scenarioButton_, enabled);
+    setControlEnabled(organismButton_, enabled);
+    setControlEnabled(addCountStepper_, enabled);
+    setControlEnabled(addButton_, enabled);
+    setControlEnabled(clearAllButton_, enabled);
+    setControlEnabled(clearAllConfirmCheckbox_, enabled);
+    if (!enabled) {
+        setOrganismListVisible(false);
+        setScenarioColumnVisible(false);
+    }
+    updateClearAllState();
+}
+
+void TrainingPopulationPanel::setControlEnabled(lv_obj_t* control, bool enabled)
+{
+    if (!control) {
+        return;
+    }
+    if (enabled) {
+        lv_obj_clear_state(control, LV_STATE_DISABLED);
+        lv_obj_set_style_opa(control, LV_OPA_COVER, 0);
+    }
+    else {
+        lv_obj_add_state(control, LV_STATE_DISABLED);
+        lv_obj_set_style_opa(control, LV_OPA_50, 0);
+    }
 }
 
 void TrainingPopulationPanel::updateSelectorLabels()
@@ -444,9 +485,6 @@ void TrainingPopulationPanel::updateSelectorLabels()
         scenarioButton_, std::string("Scenario: ") + Scenario::toString(selectedScenario_));
     setActionButtonText(
         organismButton_, std::string("Organism Type: ") + organismLabel(selectedOrganism_));
-    setActionButtonText(brainAButton_, std::string("Brain Type A: ") + brainA_);
-    const std::string brainBText = brainB_.empty() ? "None" : brainB_;
-    setActionButtonText(brainBButton_, std::string("Brain Type B: ") + brainBText);
 }
 
 void TrainingPopulationPanel::setEvolutionStarted(bool started)
@@ -463,36 +501,60 @@ void TrainingPopulationPanel::setEvolutionCompleted()
 
 void TrainingPopulationPanel::setPopulationTotal(int total)
 {
-    if (total <= 0) {
+    if (total < 0) {
+        return;
+    }
+    if (total == 0) {
+        trainingSpec_.population.clear();
+        applySpecUpdates();
+        syncUiFromState();
         return;
     }
 
-    const int desired = std::clamp(total, kPopulationMin, kPopulationMax);
-    const int currentTotal = countA_ + countB_;
-    if (currentTotal == 0) {
-        countA_ = desired;
-        countB_ = 0;
-        applySpec();
+    int desiredTotal = total;
+    const int minTotal = computeSeedCount();
+    if (desiredTotal < minTotal) {
+        desiredTotal = minTotal;
+    }
+
+    int currentTotal = computeTotalPopulation();
+    if (desiredTotal == currentTotal) {
         return;
     }
 
-    const int delta = desired - currentTotal;
-    if (delta > 0) {
-        countA_ += delta;
+    if (desiredTotal > currentTotal) {
+        const int addCount = desiredTotal - currentTotal;
+        PopulationSpec& spec = ensurePopulationSpec(selectedScenario_);
+        if (brainRequiresGenome_) {
+            spec.randomCount += addCount;
+            spec.count = static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
+        }
+        else {
+            spec.count += addCount;
+        }
     }
-    else if (delta < 0) {
-        int remaining = -delta;
-        const int minPrimary = kPopulationStep;
-        const int reducible = std::max(0, countA_ - minPrimary);
-        const int reducePrimary = std::min(reducible, remaining);
-        countA_ -= reducePrimary;
-        remaining -= reducePrimary;
-        if (remaining > 0) {
-            countB_ = std::max(0, countB_ - remaining);
+    else {
+        int remaining = currentTotal - desiredTotal;
+        for (auto it = trainingSpec_.population.rbegin();
+             it != trainingSpec_.population.rend() && remaining > 0;
+             ++it) {
+            if (brainRequiresGenome_) {
+                const int removeCount = std::min(remaining, it->randomCount);
+                it->randomCount -= removeCount;
+                it->count = static_cast<int>(it->seedGenomes.size()) + it->randomCount;
+                remaining -= removeCount;
+            }
+            else {
+                const int removeCount = std::min(remaining, it->count);
+                it->count -= removeCount;
+                remaining -= removeCount;
+            }
         }
     }
 
-    applySpec();
+    pruneEmptySpecs();
+    applySpecUpdates();
+    syncUiFromState();
 }
 
 void TrainingPopulationPanel::setPopulationTotalChangedCallback(
@@ -500,102 +562,103 @@ void TrainingPopulationPanel::setPopulationTotalChangedCallback(
 {
     populationTotalChangedCallback_ = callback;
     if (populationTotalChangedCallback_) {
-        populationTotalChangedCallback_(countA_ + countB_);
+        populationTotalChangedCallback_(populationTotal_);
     }
+}
+
+void TrainingPopulationPanel::addSeedGenome(const GenomeId& id, Scenario::EnumType scenarioId)
+{
+    if (id.isNil()) {
+        return;
+    }
+    if (!brainRequiresGenome_) {
+        return;
+    }
+
+    const bool wasEmpty = trainingSpec_.population.empty();
+    PopulationSpec& spec = ensurePopulationSpec(scenarioId);
+    if (wasEmpty) {
+        selectedScenario_ = scenarioId;
+    }
+    if (std::find(spec.seedGenomes.begin(), spec.seedGenomes.end(), id) != spec.seedGenomes.end()) {
+        return;
+    }
+
+    spec.seedGenomes.push_back(id);
+    spec.count = static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
+    applySpecUpdates();
+    syncUiFromState();
 }
 
 void TrainingPopulationPanel::refreshFromSpec()
 {
-    if (trainingSpec_.population.size() > 2) {
-        trainingSpec_.population.resize(2);
-    }
-
     selectedScenario_ = trainingSpec_.scenarioId;
     selectedOrganism_ = trainingSpec_.organismType;
     setBrainOptionsForOrganism(selectedOrganism_);
 
-    if (trainingSpec_.population.empty()) {
-        brainA_ = brainOptions_.front().kind;
-        brainB_.clear();
-        countA_ = evolutionConfig_.populationSize;
-        countB_ = 0;
-    }
-    else {
-        brainA_ = trainingSpec_.population[0].brainKind;
-        countA_ = trainingSpec_.population[0].count;
-        if (trainingSpec_.population.size() > 1) {
-            brainB_ = trainingSpec_.population[1].brainKind;
-            countB_ = trainingSpec_.population[1].count;
+    for (auto& spec : trainingSpec_.population) {
+        spec.brainKind = brainKind_;
+        spec.brainVariant.reset();
+        if (!brainRequiresGenome_) {
+            spec.seedGenomes.clear();
+            spec.randomCount = 0;
         }
-        else {
-            brainB_.clear();
-            countB_ = 0;
-        }
-    }
-
-    bool brainAValid = false;
-    for (const auto& option : brainOptions_) {
-        if (option.kind == brainA_) {
-            brainAValid = true;
-            break;
-        }
-    }
-    if (!brainAValid) {
-        brainA_ = brainOptions_.front().kind;
-    }
-
-    if (!brainB_.empty()) {
-        bool found = false;
-        for (const auto& option : brainOptions_) {
-            if (option.kind == brainB_) {
-                found = true;
-                break;
+        if (brainRequiresGenome_) {
+            const int seedCount = static_cast<int>(spec.seedGenomes.size());
+            if (spec.count < seedCount) {
+                spec.count = seedCount;
             }
-        }
-        if (!found) {
-            brainB_.clear();
-            countB_ = 0;
+            if (spec.randomCount < 0) {
+                spec.randomCount = 0;
+            }
+            spec.count = seedCount + spec.randomCount;
         }
     }
 
-    clampCounts(countA_, countB_);
-    if (countB_ == 0) {
-        brainB_.clear();
-    }
-    updatePopulationSpec();
+    pruneEmptySpecs();
+    applySpecUpdates();
     syncUiFromState();
 }
 
-void TrainingPopulationPanel::applySpec()
+void TrainingPopulationPanel::applySpecUpdates()
 {
-    clampCounts(countA_, countB_);
-    if (countB_ == 0) {
-        brainB_.clear();
+    trainingSpec_.organismType = selectedOrganism_;
+    for (auto& spec : trainingSpec_.population) {
+        spec.brainKind = brainKind_;
+        spec.brainVariant.reset();
+        if (brainRequiresGenome_) {
+            if (spec.randomCount < 0) {
+                spec.randomCount = 0;
+            }
+            spec.count = static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
+        }
+        else {
+            spec.seedGenomes.clear();
+            spec.randomCount = 0;
+            if (spec.count < 0) {
+                spec.count = 0;
+            }
+        }
     }
-    updatePopulationSpec();
-    syncUiFromState();
+    updatePrimaryScenario();
+    populationTotal_ = computeTotalPopulation();
+    evolutionConfig_.populationSize = populationTotal_;
+    if (populationTotalChangedCallback_) {
+        populationTotalChangedCallback_(populationTotal_);
+    }
 }
 
 void TrainingPopulationPanel::setBrainOptionsForOrganism(OrganismType organismType)
 {
     brainOptions_ = getBrainOptions(organismType);
+    if (brainOptions_.empty()) {
+        brainKind_ = TrainingBrainKind::Random;
+        brainRequiresGenome_ = false;
+        return;
+    }
 
-    if (viewController_->hasView("brain_a_select")) {
-        createBrainSelectView(
-            viewController_->getView("brain_a_select"),
-            "Brain Type A",
-            false,
-            brainAButtonToValue_,
-            onBrainASelected);
-    }
-    if (viewController_->hasView("brain_b_select")) {
-        createBrainSelectView(
-            viewController_->getView("brain_b_select"),
-            "Brain Type B",
-            true,
-            brainBButtonToValue_,
-            onBrainBSelected);
-    }
+    brainKind_ = brainOptions_.front().kind;
+    brainRequiresGenome_ = brainOptions_.front().requiresGenome;
 }
 
 void TrainingPopulationPanel::syncUiFromState()
@@ -603,95 +666,505 @@ void TrainingPopulationPanel::syncUiFromState()
     ignoreEvents_ = true;
 
     updateSelectorLabels();
-    if (totalCountLabel_) {
-        const std::string text = "Total: " + std::to_string(countA_ + countB_);
-        lv_label_set_text(totalCountLabel_, text.c_str());
+    updateCountsLabel();
+
+    if (addCountStepper_) {
+        LVGLBuilder::ActionStepperBuilder::setValue(addCountStepper_, addCount_);
     }
 
-    if (countAStepper_) {
-        LVGLBuilder::ActionStepperBuilder::setValue(countAStepper_, countA_);
-    }
-    if (countBStepper_) {
-        LVGLBuilder::ActionStepperBuilder::setValue(countBStepper_, countB_);
-    }
-
+    rebuildPopulationList();
+    updateClearAllState();
     updateControlsEnabled();
     ignoreEvents_ = false;
 }
 
-void TrainingPopulationPanel::updatePopulationSpec()
+void TrainingPopulationPanel::updateCountsLabel()
 {
-    trainingSpec_.scenarioId = selectedScenario_;
-    trainingSpec_.organismType = selectedOrganism_;
+    if (!totalCountLabel_) {
+        return;
+    }
 
-    std::vector<PopulationSpec> existing = trainingSpec_.population;
-    trainingSpec_.population.clear();
-    PopulationSpec primary;
-    for (const auto& entry : existing) {
-        if (entry.brainKind == brainA_) {
-            primary = entry;
-            break;
+    const int seedCount = computeSeedCount();
+    const int randomCount = computeRandomCount();
+    const int totalCount = computeTotalPopulation();
+
+    std::string text = "Total: " + std::to_string(totalCount);
+    if (brainRequiresGenome_) {
+        text += "  Seeds: " + std::to_string(seedCount);
+        text += "  Random: " + std::to_string(randomCount);
+    }
+
+    lv_label_set_text(totalCountLabel_, text.c_str());
+}
+
+void TrainingPopulationPanel::updatePrimaryScenario()
+{
+    if (!trainingSpec_.population.empty()) {
+        trainingSpec_.scenarioId = trainingSpec_.population.front().scenarioId;
+    }
+    else {
+        trainingSpec_.scenarioId = selectedScenario_;
+    }
+}
+
+PopulationSpec* TrainingPopulationPanel::findPopulationSpec(Scenario::EnumType scenarioId)
+{
+    for (auto& spec : trainingSpec_.population) {
+        if (spec.scenarioId == scenarioId) {
+            return &spec;
         }
     }
-    primary.brainKind = brainA_;
-    const bool primaryGenome = requiresGenome(brainOptions_, brainA_);
-    applyCounts(primary, countA_, primaryGenome);
-    trainingSpec_.population.push_back(primary);
+    return nullptr;
+}
 
-    if (!brainB_.empty() && countB_ > 0) {
-        PopulationSpec secondary;
-        for (const auto& entry : existing) {
-            if (entry.brainKind == brainB_) {
-                secondary = entry;
-                break;
+PopulationSpec& TrainingPopulationPanel::ensurePopulationSpec(Scenario::EnumType scenarioId)
+{
+    if (auto* spec = findPopulationSpec(scenarioId)) {
+        return *spec;
+    }
+
+    PopulationSpec spec;
+    spec.scenarioId = scenarioId;
+    spec.brainKind = brainKind_;
+    spec.brainVariant.reset();
+    spec.count = 0;
+    spec.randomCount = 0;
+    trainingSpec_.population.push_back(spec);
+    return trainingSpec_.population.back();
+}
+
+void TrainingPopulationPanel::pruneEmptySpecs()
+{
+    auto isEmpty = [&](const PopulationSpec& spec) {
+        if (brainRequiresGenome_) {
+            return spec.seedGenomes.empty() && spec.randomCount == 0;
+        }
+        return spec.count <= 0;
+    };
+
+    trainingSpec_.population.erase(
+        std::remove_if(trainingSpec_.population.begin(), trainingSpec_.population.end(), isEmpty),
+        trainingSpec_.population.end());
+}
+
+void TrainingPopulationPanel::removeEntry(size_t index)
+{
+    if (index >= populationEntries_.size()) {
+        return;
+    }
+
+    const PopulationEntry& entry = populationEntries_[index];
+    PopulationSpec* spec = findPopulationSpec(entry.scenarioId);
+    if (!spec) {
+        return;
+    }
+
+    if (brainRequiresGenome_) {
+        if (entry.genomeId.has_value()) {
+            auto it = std::find(
+                spec->seedGenomes.begin(), spec->seedGenomes.end(), entry.genomeId.value());
+            if (it != spec->seedGenomes.end()) {
+                spec->seedGenomes.erase(it);
             }
         }
-        secondary.brainKind = brainB_;
-        const bool secondaryGenome = requiresGenome(brainOptions_, brainB_);
-        applyCounts(secondary, countB_, secondaryGenome);
-        trainingSpec_.population.push_back(secondary);
+        else if (spec->randomCount > 0) {
+            spec->randomCount -= 1;
+        }
+        spec->count = static_cast<int>(spec->seedGenomes.size()) + spec->randomCount;
+    }
+    else {
+        if (spec->count > 0) {
+            spec->count -= 1;
+        }
     }
 
-    const int total = countA_ + countB_;
-    evolutionConfig_.populationSize = total;
-    if (populationTotalChangedCallback_) {
-        populationTotalChangedCallback_(total);
+    pruneEmptySpecs();
+    applySpecUpdates();
+    syncUiFromState();
+}
+
+int TrainingPopulationPanel::computeTotalPopulation() const
+{
+    int total = 0;
+    for (const auto& spec : trainingSpec_.population) {
+        if (brainRequiresGenome_) {
+            total += static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
+        }
+        else {
+            total += spec.count;
+        }
     }
+    return total;
+}
+
+int TrainingPopulationPanel::computeSeedCount() const
+{
+    int total = 0;
+    for (const auto& spec : trainingSpec_.population) {
+        total += static_cast<int>(spec.seedGenomes.size());
+    }
+    return total;
+}
+
+int TrainingPopulationPanel::computeRandomCount() const
+{
+    if (!brainRequiresGenome_) {
+        return 0;
+    }
+    int total = 0;
+    for (const auto& spec : trainingSpec_.population) {
+        total += spec.randomCount;
+    }
+    return total;
+}
+
+std::string TrainingPopulationPanel::formatEntryLabel(const PopulationEntry& entry, int index) const
+{
+    std::ostringstream oss;
+    if (entry.genomeId.has_value()) {
+        oss << "Genome " << entry.genomeId->toShortString();
+    }
+    else if (brainRequiresGenome_) {
+        oss << "Random " << (index + 1);
+    }
+    else {
+        oss << "Individual " << (index + 1);
+    }
+    oss << "\nScenario: " << Scenario::toString(entry.scenarioId);
+    return oss.str();
+}
+
+std::string TrainingPopulationPanel::formatEntryDetailText(const PopulationEntry& entry) const
+{
+    std::ostringstream oss;
+    if (!entry.genomeId.has_value()) {
+        oss << "Random Individual\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        if (brainRequiresGenome_) {
+            oss << "Genome: generated at training start\n";
+        }
+        else {
+            oss << "Genome: not required for this brain\n";
+        }
+        return oss.str();
+    }
+
+    const GenomeId genomeId = entry.genomeId.value();
+    if (!wsService_) {
+        oss << "Genome ID: " << genomeId.toString() << "\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        oss << "Metadata unavailable (no WebSocket service)";
+        return oss.str();
+    }
+    if (!wsService_->isConnected()) {
+        oss << "Genome ID: " << genomeId.toString() << "\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        oss << "Metadata unavailable (not connected)";
+        return oss.str();
+    }
+
+    Api::GenomeGet::Command cmd{ .id = genomeId };
+    auto response = wsService_->sendCommandAndGetResponse<Api::GenomeGet::Okay>(cmd, 5000);
+    if (response.isError()) {
+        oss << "Genome ID: " << genomeId.toString() << "\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        oss << "Metadata unavailable (" << response.errorValue() << ")";
+        return oss.str();
+    }
+    if (response.value().isError()) {
+        oss << "Genome ID: " << genomeId.toString() << "\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        oss << "Metadata unavailable (" << response.value().errorValue().message << ")";
+        return oss.str();
+    }
+
+    const auto& ok = response.value().value();
+    if (!ok.found) {
+        oss << "Genome ID: " << genomeId.toString() << "\n";
+        oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+        oss << "Metadata unavailable (genome not found)";
+        return oss.str();
+    }
+
+    const GenomeMetadata& meta = ok.metadata;
+    oss << "Genome ID: " << genomeId.toString() << "\n";
+    if (!meta.name.empty()) {
+        oss << "Name: " << meta.name << "\n";
+    }
+    oss << "Training Scenario: " << Scenario::toString(entry.scenarioId) << "\n";
+    oss << "Scenario: " << Scenario::toString(meta.scenarioId) << "\n";
+    oss << "Fitness: " << std::fixed << std::setprecision(3) << meta.fitness << "\n";
+    oss << "Generation: " << meta.generation << "\n";
+    oss << "Created: " << meta.createdTimestamp << "\n";
+    if (!meta.notes.empty()) {
+        oss << "Notes: " << meta.notes << "\n";
+    }
+    if (meta.organismType.has_value()) {
+        oss << "Organism Type: " << reflect::enum_name(meta.organismType.value()) << "\n";
+    }
+    if (meta.brainKind.has_value()) {
+        oss << "Brain Kind: " << meta.brainKind.value() << "\n";
+    }
+    if (meta.brainVariant.has_value()) {
+        oss << "Brain Variant: " << meta.brainVariant.value() << "\n";
+    }
+    if (meta.trainingSessionId.has_value()) {
+        oss << "Training Session: " << meta.trainingSessionId->toShortString() << "\n";
+    }
+    return oss.str();
+}
+
+void TrainingPopulationPanel::rebuildPopulationList()
+{
+    if (!populationList_) {
+        return;
+    }
+
+    entryContexts_.clear();
+    populationEntries_.clear();
+    lv_obj_clean(populationList_);
+
+    for (const auto& spec : trainingSpec_.population) {
+        if (brainRequiresGenome_) {
+            for (const auto& id : spec.seedGenomes) {
+                populationEntries_.push_back(
+                    PopulationEntry{
+                        .scenarioId = spec.scenarioId,
+                        .genomeId = id,
+                        .isRandom = false,
+                    });
+            }
+            for (int i = 0; i < spec.randomCount; ++i) {
+                populationEntries_.push_back(
+                    PopulationEntry{
+                        .scenarioId = spec.scenarioId,
+                        .genomeId = std::nullopt,
+                        .isRandom = true,
+                    });
+            }
+        }
+        else {
+            for (int i = 0; i < spec.count; ++i) {
+                populationEntries_.push_back(
+                    PopulationEntry{
+                        .scenarioId = spec.scenarioId,
+                        .genomeId = std::nullopt,
+                        .isRandom = true,
+                    });
+            }
+        }
+    }
+
+    if (populationEntries_.empty()) {
+        lv_obj_t* emptyLabel = lv_label_create(populationList_);
+        lv_label_set_text(emptyLabel, "No individuals yet");
+        lv_obj_set_style_text_color(emptyLabel, lv_color_hex(0x999999), 0);
+        lv_obj_set_style_text_font(emptyLabel, &lv_font_montserrat_12, 0);
+        return;
+    }
+
+    entryContexts_.reserve(populationEntries_.size());
+    for (size_t i = 0; i < populationEntries_.size(); ++i) {
+        auto context = std::make_unique<EntryContext>();
+        context->panel = this;
+        context->index = i;
+        const std::string label = formatEntryLabel(populationEntries_[i], static_cast<int>(i));
+        LVGLBuilder::actionButton(populationList_)
+            .text(label.c_str())
+            .height(kEntryRowHeight)
+            .width(LV_PCT(100))
+            .layoutColumn()
+            .alignLeft()
+            .callback(onEntryClicked, context.get())
+            .buildOrLog();
+        entryContexts_.push_back(std::move(context));
+    }
+}
+
+void TrainingPopulationPanel::openDetailModal(size_t index)
+{
+    if (index >= populationEntries_.size()) {
+        return;
+    }
+
+    closeDetailModal();
+    detailEntryIndex_ = index;
+
+    detailOverlay_ = lv_obj_create(lv_layer_top());
+    lv_obj_set_size(detailOverlay_, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_color(detailOverlay_, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_opa(detailOverlay_, LV_OPA_60, 0);
+    lv_obj_clear_flag(detailOverlay_, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_move_foreground(detailOverlay_);
+
+    lv_obj_t* modal = lv_obj_create(detailOverlay_);
+    lv_obj_set_size(modal, 420, 440);
+    lv_obj_center(modal);
+    lv_obj_set_style_bg_color(modal, lv_color_hex(0x1E1E2E), 0);
+    lv_obj_set_style_bg_opa(modal, LV_OPA_80, 0);
+    lv_obj_set_style_radius(modal, 12, 0);
+    lv_obj_set_style_pad_all(modal, 12, 0);
+    lv_obj_set_style_pad_row(modal, 8, 0);
+    lv_obj_set_flex_flow(modal, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(modal, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(modal, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* titleLabel = lv_label_create(modal);
+    lv_label_set_text(titleLabel, "Population Entry");
+    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFDD66), 0);
+    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_18, 0);
+
+    lv_obj_t* detailContainer = lv_obj_create(modal);
+    lv_obj_set_width(detailContainer, LV_PCT(100));
+    lv_obj_set_height(detailContainer, LV_PCT(100));
+    lv_obj_set_flex_grow(detailContainer, 1);
+    lv_obj_set_style_bg_opa(detailContainer, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(detailContainer, 0, 0);
+    lv_obj_set_style_pad_all(detailContainer, 0, 0);
+    lv_obj_set_flex_flow(detailContainer, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_scroll_dir(detailContainer, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(detailContainer, LV_SCROLLBAR_MODE_AUTO);
+
+    const std::string detailText = formatEntryDetailText(populationEntries_[index]);
+    lv_obj_t* detailLabel = lv_label_create(detailContainer);
+    lv_label_set_text(detailLabel, detailText.c_str());
+    lv_label_set_long_mode(detailLabel, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(detailLabel, LV_PCT(100));
+    lv_obj_set_style_text_color(detailLabel, lv_color_hex(0xCCCCCC), 0);
+    lv_obj_set_style_text_font(detailLabel, &lv_font_montserrat_12, 0);
+
+    lv_obj_t* bottomRow = lv_obj_create(modal);
+    lv_obj_set_size(bottomRow, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(bottomRow, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(bottomRow, 0, 0);
+    lv_obj_set_style_pad_all(bottomRow, 0, 0);
+    lv_obj_set_style_pad_column(bottomRow, 12, 0);
+    lv_obj_set_flex_flow(bottomRow, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(
+        bottomRow, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(bottomRow, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* leftButtons = lv_obj_create(bottomRow);
+    lv_obj_set_width(leftButtons, LV_SIZE_CONTENT);
+    lv_obj_set_height(leftButtons, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(leftButtons, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(leftButtons, 0, 0);
+    lv_obj_set_style_pad_all(leftButtons, 0, 0);
+    lv_obj_set_style_pad_row(leftButtons, 8, 0);
+    lv_obj_set_flex_flow(leftButtons, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        leftButtons, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(leftButtons, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* rightButtons = lv_obj_create(bottomRow);
+    lv_obj_set_width(rightButtons, LV_SIZE_CONTENT);
+    lv_obj_set_height(rightButtons, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(rightButtons, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(rightButtons, 0, 0);
+    lv_obj_set_style_pad_all(rightButtons, 0, 0);
+    lv_obj_set_style_pad_row(rightButtons, 8, 0);
+    lv_obj_set_flex_flow(rightButtons, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(
+        rightButtons, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_clear_flag(rightButtons, LV_OBJ_FLAG_SCROLLABLE);
+
+    LVGLBuilder::actionButton(leftButtons)
+        .text("OK")
+        .mode(LVGLBuilder::ActionMode::Push)
+        .height(LVGLBuilder::Style::ACTION_SIZE)
+        .width(120)
+        .layoutRow()
+        .alignLeft()
+        .backgroundColor(0x00AA66)
+        .callback(onDetailOkClicked, this)
+        .buildOrLog();
+
+    lv_obj_t* deleteRow = lv_obj_create(rightButtons);
+    lv_obj_set_size(deleteRow, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(deleteRow, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(deleteRow, 0, 0);
+    lv_obj_set_style_pad_all(deleteRow, 0, 0);
+    lv_obj_set_style_pad_column(deleteRow, 6, 0);
+    lv_obj_set_flex_flow(deleteRow, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(
+        deleteRow, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(deleteRow, LV_OBJ_FLAG_SCROLLABLE);
+
+    detailRemoveButton_ = LVGLBuilder::actionButton(deleteRow)
+                              .text("Remove")
+                              .mode(LVGLBuilder::ActionMode::Push)
+                              .height(LVGLBuilder::Style::ACTION_SIZE)
+                              .width(120)
+                              .layoutRow()
+                              .alignLeft()
+                              .backgroundColor(0xCC0000)
+                              .callback(onDetailRemoveClicked, this)
+                              .buildOrLog();
+
+    detailConfirmCheckbox_ = lv_checkbox_create(deleteRow);
+    lv_checkbox_set_text(detailConfirmCheckbox_, "Confirm");
+    lv_obj_set_style_text_font(detailConfirmCheckbox_, &lv_font_montserrat_12, 0);
+    lv_obj_add_event_cb(
+        detailConfirmCheckbox_, onDetailConfirmToggled, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_clear_flag(detailConfirmCheckbox_, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_opa(detailConfirmCheckbox_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(detailConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_all(detailConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_column(detailConfirmCheckbox_, 8, 0);
+
+    updateDetailRemoveState();
+}
+
+void TrainingPopulationPanel::closeDetailModal()
+{
+    if (detailOverlay_) {
+        lv_obj_del(detailOverlay_);
+        detailOverlay_ = nullptr;
+    }
+    detailEntryIndex_.reset();
+    detailConfirmCheckbox_ = nullptr;
+    detailRemoveButton_ = nullptr;
+}
+
+void TrainingPopulationPanel::updateDetailRemoveState()
+{
+    const bool enabled =
+        detailConfirmCheckbox_ && lv_obj_has_state(detailConfirmCheckbox_, LV_STATE_CHECKED);
+    setControlEnabled(detailRemoveButton_, enabled);
+}
+
+void TrainingPopulationPanel::updateClearAllState()
+{
+    const bool hasPopulation = computeTotalPopulation() > 0;
+    const bool confirmed =
+        clearAllConfirmCheckbox_ && lv_obj_has_state(clearAllConfirmCheckbox_, LV_STATE_CHECKED);
+    if (!hasPopulation && clearAllConfirmCheckbox_) {
+        lv_obj_clear_state(clearAllConfirmCheckbox_, LV_STATE_CHECKED);
+    }
+    setControlEnabled(clearAllButton_, hasPopulation && confirmed && !evolutionStarted_);
 }
 
 void TrainingPopulationPanel::onScenarioButtonClicked(lv_event_t* e)
 {
     auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
     if (!self || self->ignoreEvents_) return;
-    self->viewController_->showView("scenario_select");
+    self->setOrganismListVisible(false);
+    self->setScenarioColumnVisible(true);
 }
 
 void TrainingPopulationPanel::onOrganismButtonClicked(lv_event_t* e)
 {
     auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
     if (!self || self->ignoreEvents_) return;
-    self->viewController_->showView("organism_select");
+    self->setScenarioColumnVisible(false);
+    self->setOrganismListVisible(!self->organismListVisible_);
 }
 
-void TrainingPopulationPanel::onBrainAButtonClicked(lv_event_t* e)
-{
-    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_) return;
-    self->viewController_->showView("brain_a_select");
-}
-
-void TrainingPopulationPanel::onBrainBButtonClicked(lv_event_t* e)
-{
-    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_) return;
-    self->viewController_->showView("brain_b_select");
-}
-
-void TrainingPopulationPanel::onSelectionBackClicked(lv_event_t* e)
+void TrainingPopulationPanel::onScenarioBackClicked(lv_event_t* e)
 {
     auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
     if (!self) return;
-    self->viewController_->showView("main");
+    self->setScenarioColumnVisible(false);
 }
 
 void TrainingPopulationPanel::onScenarioSelected(lv_event_t* e)
@@ -705,8 +1178,10 @@ void TrainingPopulationPanel::onScenarioSelected(lv_event_t* e)
         return;
     }
     self->selectedScenario_ = it->second;
-    self->applySpec();
-    self->viewController_->showView("main");
+    self->applySpecUpdates();
+    self->syncUiFromState();
+    self->setOrganismListVisible(false);
+    self->setScenarioColumnVisible(false);
 }
 
 void TrainingPopulationPanel::onOrganismSelected(lv_event_t* e)
@@ -721,81 +1196,151 @@ void TrainingPopulationPanel::onOrganismSelected(lv_event_t* e)
     }
     self->selectedOrganism_ = it->second;
     self->setBrainOptionsForOrganism(self->selectedOrganism_);
-
-    int total = self->countA_ + self->countB_;
-    if (total <= 0) {
-        total = self->evolutionConfig_.populationSize;
-    }
-    self->brainA_ = self->brainOptions_.front().kind;
-    self->brainB_.clear();
-    self->countA_ = total;
-    self->countB_ = 0;
-    self->applySpec();
-    self->viewController_->showView("main");
+    self->trainingSpec_.population.clear();
+    self->populationTotal_ = 0;
+    self->applySpecUpdates();
+    self->syncUiFromState();
+    self->setOrganismListVisible(false);
 }
 
-void TrainingPopulationPanel::onBrainASelected(lv_event_t* e)
+void TrainingPopulationPanel::onAddCountChanged(lv_event_t* e)
 {
     auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_) return;
-
-    lv_obj_t* button = static_cast<lv_obj_t*>(lv_event_get_target(e));
-    auto it = self->brainAButtonToValue_.find(button);
-    if (it == self->brainAButtonToValue_.end()) {
+    if (!self || !self->addCountStepper_ || self->ignoreEvents_) {
         return;
     }
-    self->brainA_ = it->second;
-    self->applySpec();
-    self->viewController_->showView("main");
+
+    int32_t value = LVGLBuilder::ActionStepperBuilder::getValue(self->addCountStepper_);
+    if (value < kAddCountMin) {
+        value = kAddCountMin;
+    }
+    self->addCount_ = value;
 }
 
-void TrainingPopulationPanel::onBrainBSelected(lv_event_t* e)
+void TrainingPopulationPanel::onAddClicked(lv_event_t* e)
 {
     auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_) return;
-
-    lv_obj_t* button = static_cast<lv_obj_t*>(lv_event_get_target(e));
-    auto it = self->brainBButtonToValue_.find(button);
-    if (it == self->brainBButtonToValue_.end()) {
+    if (!self || self->ignoreEvents_ || self->evolutionStarted_) {
         return;
     }
-    if (it->second.empty()) {
-        self->brainB_.clear();
-        self->countB_ = 0;
+
+    if (self->addCount_ <= 0) {
+        return;
+    }
+
+    PopulationSpec& spec = self->ensurePopulationSpec(self->selectedScenario_);
+    if (self->brainRequiresGenome_) {
+        spec.randomCount += self->addCount_;
+        spec.count = static_cast<int>(spec.seedGenomes.size()) + spec.randomCount;
     }
     else {
-        self->brainB_ = it->second;
-        if (self->countB_ == 0) {
-            self->countB_ = kPopulationStep;
-        }
+        spec.count += self->addCount_;
     }
-    self->applySpec();
-    self->viewController_->showView("main");
+
+    self->applySpecUpdates();
+    self->syncUiFromState();
 }
 
-void TrainingPopulationPanel::onCountAChanged(lv_event_t* e)
+void TrainingPopulationPanel::onEntryClicked(lv_event_t* e)
 {
-    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_ || !self->countAStepper_) return;
-
-    int32_t value = LVGLBuilder::ActionStepperBuilder::getValue(self->countAStepper_);
-    self->countA_ = value;
-    self->applySpec();
-}
-
-void TrainingPopulationPanel::onCountBChanged(lv_event_t* e)
-{
-    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
-    if (!self || self->ignoreEvents_ || !self->countBStepper_) return;
-
-    if (self->brainB_.empty()) {
-        LVGLBuilder::ActionStepperBuilder::setValue(self->countBStepper_, 0);
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
         return;
     }
 
-    int32_t value = LVGLBuilder::ActionStepperBuilder::getValue(self->countBStepper_);
-    self->countB_ = value;
-    self->applySpec();
+    auto* context = static_cast<EntryContext*>(lv_event_get_user_data(e));
+    if (!context || !context->panel) {
+        return;
+    }
+
+    context->panel->openDetailModal(context->index);
+}
+
+void TrainingPopulationPanel::onDetailOkClicked(lv_event_t* e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
+        return;
+    }
+
+    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    self->closeDetailModal();
+}
+
+void TrainingPopulationPanel::onDetailRemoveClicked(lv_event_t* e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
+        return;
+    }
+
+    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    if (!self->detailConfirmCheckbox_
+        || !lv_obj_has_state(self->detailConfirmCheckbox_, LV_STATE_CHECKED)) {
+        return;
+    }
+
+    if (self->detailEntryIndex_.has_value()) {
+        self->removeEntry(self->detailEntryIndex_.value());
+    }
+    self->closeDetailModal();
+}
+
+void TrainingPopulationPanel::onDetailConfirmToggled(lv_event_t* e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) {
+        return;
+    }
+
+    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    self->updateDetailRemoveState();
+}
+
+void TrainingPopulationPanel::onClearAllClicked(lv_event_t* e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) {
+        return;
+    }
+
+    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    if (!self->clearAllConfirmCheckbox_
+        || !lv_obj_has_state(self->clearAllConfirmCheckbox_, LV_STATE_CHECKED)) {
+        return;
+    }
+
+    if (self->clearAllConfirmCheckbox_) {
+        lv_obj_clear_state(self->clearAllConfirmCheckbox_, LV_STATE_CHECKED);
+    }
+    self->trainingSpec_.population.clear();
+    self->applySpecUpdates();
+    self->syncUiFromState();
+}
+
+void TrainingPopulationPanel::onClearAllConfirmToggled(lv_event_t* e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) {
+        return;
+    }
+
+    auto* self = static_cast<TrainingPopulationPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    self->updateClearAllState();
 }
 
 } // namespace Ui

--- a/apps/src/ui/state-machine/Event.h
+++ b/apps/src/ui/state-machine/Event.h
@@ -171,6 +171,16 @@ struct GenomeLoadClickedEvent {
     static constexpr const char* name() { return "GenomeLoadClickedEvent"; }
 };
 
+struct OpenTrainingGenomeBrowserClickedEvent {
+    static constexpr const char* name() { return "OpenTrainingGenomeBrowserClickedEvent"; }
+};
+
+struct GenomeAddToTrainingClickedEvent {
+    GenomeId genomeId;
+    Scenario::EnumType scenarioId = Scenario::EnumType::TreeGermination;
+    static constexpr const char* name() { return "GenomeAddToTrainingClickedEvent"; }
+};
+
 /**
  * @brief Physics settings received from server.
  */
@@ -240,6 +250,8 @@ using Event = std::variant<
     TrainingResultSaveClickedEvent,
     TrainingResultDiscardClickedEvent,
     GenomeLoadClickedEvent,
+    OpenTrainingGenomeBrowserClickedEvent,
+    GenomeAddToTrainingClickedEvent,
     RequestWorldUpdateCommand,
 
     // Server data updates

--- a/apps/src/ui/state-machine/states/Training.cpp
+++ b/apps/src/ui/state-machine/states/Training.cpp
@@ -682,6 +682,45 @@ State::Any Training::onEvent(const GenomeLoadClickedEvent& evt, StateMachine& sm
     return SimRunning{};
 }
 
+State::Any Training::onEvent(const OpenTrainingGenomeBrowserClickedEvent& /*evt*/, StateMachine& sm)
+{
+    if (!view_) {
+        LOG_WARN(State, "Training view not available for genome browser");
+        return std::move(*this);
+    }
+
+    auto* uiManager = sm.getUiComponentManager();
+    if (!uiManager) {
+        LOG_WARN(State, "UiComponentManager not available for genome browser");
+        return std::move(*this);
+    }
+
+    if (auto* panel = uiManager->getExpandablePanel()) {
+        panel->clearContent();
+        panel->show();
+    }
+
+    view_->clearPanelContent();
+    view_->createGenomeBrowserPanel();
+
+    if (auto* iconRail = uiManager->getIconRail()) {
+        iconRail->selectIcon(IconId::GENOME_BROWSER);
+    }
+
+    return std::move(*this);
+}
+
+State::Any Training::onEvent(const GenomeAddToTrainingClickedEvent& evt, StateMachine& /*sm*/)
+{
+    if (!view_) {
+        LOG_WARN(State, "Training view not available for genome add");
+        return std::move(*this);
+    }
+
+    view_->addGenomeToTraining(evt.genomeId, evt.scenarioId);
+    return std::move(*this);
+}
+
 State::Any Training::onEvent(const UiApi::Exit::Cwc& cwc, StateMachine& /*sm*/)
 {
     LOG_INFO(State, "Exit command received, shutting down");

--- a/apps/src/ui/state-machine/states/Training.h
+++ b/apps/src/ui/state-machine/states/Training.h
@@ -42,6 +42,8 @@ struct Training {
     Any onEvent(const TrainingResultSaveClickedEvent& evt, StateMachine& sm);
     Any onEvent(const TrainingResultDiscardClickedEvent& evt, StateMachine& sm);
     Any onEvent(const GenomeLoadClickedEvent& evt, StateMachine& sm);
+    Any onEvent(const OpenTrainingGenomeBrowserClickedEvent& evt, StateMachine& sm);
+    Any onEvent(const GenomeAddToTrainingClickedEvent& evt, StateMachine& sm);
     Any onEvent(const UiApi::Exit::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::MouseDown::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::MouseMove::Cwc& cwc, StateMachine& sm);


### PR DESCRIPTION
## Summary
- Adds per-scenario support in training population configuration, allowing different scenarios for different population entries
- Moves scenarioId from TrainingSpec to PopulationSpec and Individual
- Updates TrainingPopulationPanel with scenario selection per entry
- Enhances BrowserPanel with filtering and multi-selection capabilities

<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/4b5393fd-e4b1-4f19-b9ed-ea9ad2e51971" />

## Test plan
- [x] Run training with different scenarios in the same population
- [x] Verify genome browser filtering works correctly
- [x] Check scenario selection persists across UI navigation