### PR TITLE
Add StatusGet state_details docs and network screen

### DIFF
--- a/apps/src/ui/docs/README.md
+++ b/apps/src/ui/docs/README.md
@@ -109,6 +109,7 @@ StatusGet includes state-specific details via `state_details`. For Training:
 }
 ```
 
+
 Then run:
 
 ```bash

--- a/apps/src/ui/docs/src/screens/network.md
+++ b/apps/src/ui/docs/src/screens/network.md
@@ -1,0 +1,46 @@
+# Network
+
+```plantuml
+@startsalt
+scale 1.6
+{
+  {+
+    [Home]
+    [Graphs]
+    [Scenes]
+    [Wireless]
+    [Settings]
+  } | {
+    "Network"
+    "WiFi: onionchan"
+    .
+    "Networks"
+    {
+      onionchan
+      "connected | -40 dBm | wpa2"
+      [Connected] [Forget]
+    }
+    .
+    "LAN Web UI" | [On]
+    "Incoming WebSockets" | [On]
+    .
+    "WebSocket token"
+    .
+    "IP Address:"
+    "wlan0: 192.168.1.143"
+    .
+    [Refresh]
+  }
+}
+@endsalt
+```
+
+## States
+
+```plantuml
+@startuml
+[*] --> StartMenu
+
+StartMenu --> StartMenu : Select Network
+@enduml
+```


### PR DESCRIPTION
## Summary
- Add `state_details` JSON example to UI docs README (documents `TrainingStateDetails` in `StatusGet` response).
- Add `network.md` screen documentation.

## Test plan
- [ ] Verify docs site renders correctly with `npm run dev` in `apps/src/ui/docs/`.