### PR TITLE
Add persistent user settings workflow

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -286,6 +286,7 @@ add_library(dirtsim-server-lib STATIC
     src/server/ServerConfig.cpp
     src/server/StateMachine.cpp
     src/server/TrainingResultRepository.cpp
+    src/server/UserSettings.cpp
     src/server/EventProcessor.cpp
     src/server/states/Error.cpp
     src/server/states/Evolution.cpp
@@ -331,11 +332,13 @@ add_library(dirtsim-server-lib STATIC
     src/server/api/StateGet.cpp
     src/server/api/StatusGet.cpp
     src/server/api/TimerStatsGet.cpp
+    src/server/api/UserSettingsSet.cpp
     src/server/api/TrainingResult.cpp
     src/server/api/TrainingResultDiscard.cpp
     src/server/api/TrainingResultList.cpp
     src/server/api/TrainingResultSave.cpp
     src/server/api/TrainingStreamConfigSet.cpp
+    src/server/api/UserSettingsUpdated.cpp
     src/server/api/WorldResize.cpp
 
     # Server network.
@@ -526,6 +529,7 @@ add_library(dirtsim-ui-lib STATIC
     src/ui/controls/ScenarioControlsFactory.cpp
     src/ui/controls/ScenarioPanel.cpp
     src/ui/controls/StartMenuCorePanel.cpp
+    src/ui/controls/StartMenuSettingsPanel.cpp
     src/ui/controls/StopPanel.cpp
     src/ui/controls/SparklingDuckButton.cpp
     src/ui/controls/ToggleSlider.cpp
@@ -662,6 +666,7 @@ add_executable(dirtsim-tests
     src/server/tests/StateSimRunning_test.cpp
     src/server/tests/StateUnsavedTrainingResult_test.cpp
     src/server/tests/TestStateMachineFixture.cpp
+    src/server/tests/UserSettings_test.cpp
     src/server/tests/TrainingResultRepository_test.cpp
     src/tests/MockWebSocketService.cpp
     src/ui/state-machine/tests/StateTraining_test.cpp

--- a/apps/src/audio/AudioEngine.h
+++ b/apps/src/audio/AudioEngine.h
@@ -50,6 +50,8 @@ public:
         Audio::Waveform waveform,
         uint32_t noteId);
     void enqueueNoteOff(uint32_t noteId);
+    void setMasterVolumePercent(int volumePercent);
+    int getMasterVolumePercent() const;
 
     AudioStatus getStatus() const;
 
@@ -108,6 +110,7 @@ private:
     std::atomic<double> currentEnvelopeLevel_{ 0.0 };
     std::atomic<int> currentEnvelopeState_{ static_cast<int>(Audio::EnvelopeState::Idle) };
     std::atomic<int> currentWaveform_{ static_cast<int>(Audio::Waveform::Sine) };
+    std::atomic<int> masterVolumePercent_{ 100 };
 
     std::vector<float> mixBuffer_;
     std::vector<int16_t> s16Buffer_;

--- a/apps/src/audio/AudioManager.h
+++ b/apps/src/audio/AudioManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AudioEngine.h"
+#include "audio/api/MasterVolumeSet.h"
 #include "audio/api/NoteOff.h"
 #include "audio/api/NoteOn.h"
 #include "audio/api/StatusGet.h"
@@ -25,6 +26,7 @@ public:
 
 private:
     void setupWebSocketService();
+    void handleMasterVolumeSet(AudioApi::MasterVolumeSet::Cwc cwc);
     void handleNoteOn(AudioApi::NoteOn::Cwc cwc);
     void handleNoteOff(AudioApi::NoteOff::Cwc cwc);
     void handleStatusGet(AudioApi::StatusGet::Cwc cwc);

--- a/apps/src/audio/api/AudioApiCommand.h
+++ b/apps/src/audio/api/AudioApiCommand.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "MasterVolumeSet.h"
 #include "NoteOff.h"
 #include "NoteOn.h"
 #include "StatusGet.h"
@@ -8,7 +9,8 @@
 namespace DirtSim {
 namespace AudioApi {
 
-using AudioApiCommand = std::variant<NoteOff::Command, NoteOn::Command, StatusGet::Command>;
+using AudioApiCommand =
+    std::variant<MasterVolumeSet::Command, NoteOff::Command, NoteOn::Command, StatusGet::Command>;
 
 } // namespace AudioApi
 } // namespace DirtSim

--- a/apps/src/audio/api/MasterVolumeSet.h
+++ b/apps/src/audio/api/MasterVolumeSet.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "core/CommandWithCallback.h"
+#include "core/Result.h"
+#include "server/api/ApiError.h"
+#include "server/api/ApiMacros.h"
+#include <nlohmann/json.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace AudioApi {
+namespace MasterVolumeSet {
+
+DEFINE_API_NAME(MasterVolumeSet);
+
+struct Okay;
+
+struct Command {
+    int volume_percent = 100;
+
+    API_COMMAND();
+    API_JSON_SERIALIZABLE(Command);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+struct Okay {
+    int volume_percent = 100;
+
+    API_COMMAND_NAME();
+    API_JSON_SERIALIZABLE(Okay);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+using Response = Result<Okay, ApiError>;
+using Cwc = CommandWithCallback<Command, Response>;
+
+} // namespace MasterVolumeSet
+} // namespace AudioApi
+} // namespace DirtSim

--- a/apps/src/audio/network/CommandDeserializerJson.cpp
+++ b/apps/src/audio/network/CommandDeserializerJson.cpp
@@ -1,4 +1,5 @@
 #include "CommandDeserializerJson.h"
+#include "audio/api/MasterVolumeSet.h"
 #include "audio/api/NoteOff.h"
 #include "audio/api/NoteOn.h"
 #include "audio/api/StatusGet.h"
@@ -38,6 +39,10 @@ Result<AudioApi::AudioApiCommand, ApiError> CommandDeserializerJson::deserialize
         if (commandName == AudioApi::NoteOn::Command::name()) {
             return Result<AudioApi::AudioApiCommand, ApiError>::okay(
                 AudioApi::NoteOn::Command::fromJson(cmd));
+        }
+        if (commandName == AudioApi::MasterVolumeSet::Command::name()) {
+            return Result<AudioApi::AudioApiCommand, ApiError>::okay(
+                AudioApi::MasterVolumeSet::Command::fromJson(cmd));
         }
         if (commandName == AudioApi::NoteOff::Command::name()) {
             return Result<AudioApi::AudioApiCommand, ApiError>::okay(

--- a/apps/src/cli/CommandDispatcher.cpp
+++ b/apps/src/cli/CommandDispatcher.cpp
@@ -1,4 +1,5 @@
 #include "CommandDispatcher.h"
+#include "audio/api/MasterVolumeSet.h"
 #include "audio/api/NoteOff.h"
 #include "audio/api/NoteOn.h"
 #include "audio/api/StatusGet.h"
@@ -27,6 +28,7 @@ CommandDispatcher::CommandDispatcher()
 
     registerCommand<AudioApi::NoteOff::Cwc>(audioHandlers_, audioExampleHandlers_);
     registerCommand<AudioApi::NoteOn::Cwc>(audioHandlers_, audioExampleHandlers_);
+    registerCommand<AudioApi::MasterVolumeSet::Cwc>(audioHandlers_, audioExampleHandlers_);
     registerCommand<AudioApi::StatusGet::Cwc>(audioHandlers_, audioExampleHandlers_);
 
     spdlog::debug(
@@ -66,6 +68,9 @@ CommandDispatcher::CommandDispatcher()
     registerCommand<Api::StateGet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::StatusGet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TimerStatsGet::Cwc>(serverHandlers_, serverExampleHandlers_);
+    registerCommand<Api::UserSettingsGet::Cwc>(serverHandlers_, serverExampleHandlers_);
+    registerCommand<Api::UserSettingsReset::Cwc>(serverHandlers_, serverExampleHandlers_);
+    registerCommand<Api::UserSettingsSet::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TrainingResultDiscard::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TrainingResultDelete::Cwc>(serverHandlers_, serverExampleHandlers_);
     registerCommand<Api::TrainingResultSave::Cwc>(serverHandlers_, serverExampleHandlers_);

--- a/apps/src/cli/FunctionalTestRunner.cpp
+++ b/apps/src/cli/FunctionalTestRunner.cpp
@@ -1,17 +1,25 @@
 #include "FunctionalTestRunner.h"
+#include "core/RenderMessageFull.h"
 #include "core/ScenarioId.h"
 #include "core/network/ClientHello.h"
 #include "core/network/WebSocketService.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
+#include "core/scenarios/ClockConfig.h"
 #include "os-manager/api/RestartServer.h"
 #include "os-manager/api/RestartUi.h"
+#include "os-manager/api/StopUi.h"
 #include "os-manager/api/SystemStatus.h"
 #include "server/api/GenomeDelete.h"
+#include "server/api/RenderFormatSet.h"
+#include "server/api/SimRun.h"
 #include "server/api/SimStop.h"
 #include "server/api/StateGet.h"
 #include "server/api/StatusGet.h"
 #include "server/api/TrainingResultGet.h"
 #include "server/api/TrainingResultList.h"
+#include "server/api/UserSettingsGet.h"
+#include "server/api/UserSettingsReset.h"
+#include "server/api/UserSettingsSet.h"
 #include "ui/state-machine/api/Exit.h"
 #include "ui/state-machine/api/GenomeBrowserOpen.h"
 #include "ui/state-machine/api/GenomeDetailLoad.h"
@@ -27,13 +35,16 @@
 #include "ui/state-machine/api/TrainingStart.h"
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <iostream>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
 #include <unordered_set>
 #include <variant>
 #include <vector>
+#include <zpp_bits.h>
 
 namespace DirtSim {
 namespace Client {
@@ -161,6 +172,223 @@ Result<std::monostate, std::string> waitForServerScenario(
 
         std::this_thread::sleep_for(std::chrono::milliseconds(pollDelayMs));
     }
+}
+
+Result<std::monostate, std::string> connectServerBinary(
+    Network::WebSocketService& client,
+    const std::string& serverAddress,
+    int timeoutMs,
+    bool wantsRender)
+{
+    client.setProtocol(Network::Protocol::BINARY);
+    Network::ClientHello hello{
+        .protocolVersion = Network::kClientHelloProtocolVersion,
+        .wantsRender = wantsRender,
+        .wantsEvents = false,
+    };
+    client.setClientHello(hello);
+
+    auto connectResult = client.connect(serverAddress, timeoutMs);
+    if (connectResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "Failed to connect to server: " + connectResult.errorValue());
+    }
+
+    return Result<std::monostate, std::string>::okay(std::monostate{});
+}
+
+Result<std::monostate, std::string> ensureUiInStartMenu(
+    Network::WebSocketService& uiClient, int timeoutMs)
+{
+    auto uiStatusResult = requestUiStatus(uiClient, timeoutMs);
+    if (uiStatusResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "UI StatusGet failed: " + uiStatusResult.errorValue());
+    }
+
+    if (!uiStatusResult.value().connected_to_server) {
+        return Result<std::monostate, std::string>::error("UI not connected to server");
+    }
+
+    auto uiStateResult = requestUiState(uiClient, timeoutMs);
+    if (uiStateResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "UI StateGet failed: " + uiStateResult.errorValue());
+    }
+
+    const std::string& state = uiStateResult.value().state;
+    if (state == "StartMenu") {
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }
+
+    if (state == "SimRunning" || state == "Paused") {
+        UiApi::SimStop::Command simStopCmd{};
+        auto simStopResult = unwrapResponse(
+            uiClient.sendCommandAndGetResponse<UiApi::SimStop::Okay>(simStopCmd, timeoutMs));
+        if (simStopResult.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "UI SimStop failed: " + simStopResult.errorValue());
+        }
+
+        auto startMenuResult = waitForUiState(uiClient, "StartMenu", timeoutMs);
+        if (startMenuResult.isError()) {
+            return Result<std::monostate, std::string>::error(startMenuResult.errorValue());
+        }
+
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }
+
+    return Result<std::monostate, std::string>::error(
+        "Unsupported UI state for settings tests: " + state);
+}
+
+Result<std::monostate, std::string> ensureServerIdle(
+    Network::WebSocketService& serverClient, int timeoutMs)
+{
+    auto statusResult = requestServerStatus(serverClient, timeoutMs);
+    if (statusResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "Server StatusGet failed: " + statusResult.errorValue());
+    }
+
+    const std::string& state = statusResult.value().state;
+    if (state == "Idle") {
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }
+
+    if (state == "SimRunning" || state == "SimPaused") {
+        Api::SimStop::Command simStopCmd{};
+        auto simStopResult = unwrapResponse(
+            serverClient.sendCommandAndGetResponse<Api::SimStop::OkayType>(simStopCmd, timeoutMs));
+        if (simStopResult.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "Server SimStop failed: " + simStopResult.errorValue());
+        }
+
+        auto idleResult = waitForServerState(serverClient, "Idle", timeoutMs);
+        if (idleResult.isError()) {
+            return Result<std::monostate, std::string>::error(idleResult.errorValue());
+        }
+
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }
+
+    return Result<std::monostate, std::string>::error(
+        "Unsupported server state for settings tests: " + state);
+}
+
+Result<UserSettings, std::string> fetchUserSettings(
+    Network::WebSocketService& serverClient, int timeoutMs)
+{
+    Api::UserSettingsGet::Command cmd{};
+    auto response = unwrapResponse(
+        serverClient.sendCommandAndGetResponse<Api::UserSettingsGet::Okay>(cmd, timeoutMs));
+    if (response.isError()) {
+        return Result<UserSettings, std::string>::error(
+            "UserSettingsGet failed: " + response.errorValue());
+    }
+
+    return Result<UserSettings, std::string>::okay(response.value().settings);
+}
+
+Result<UserSettings, std::string> updateUserSettings(
+    Network::WebSocketService& serverClient, const UserSettings& settings, int timeoutMs)
+{
+    Api::UserSettingsSet::Command cmd{ .settings = settings };
+    auto response = unwrapResponse(
+        serverClient.sendCommandAndGetResponse<Api::UserSettingsSet::Okay>(cmd, timeoutMs));
+    if (response.isError()) {
+        return Result<UserSettings, std::string>::error(
+            "UserSettingsSet failed: " + response.errorValue());
+    }
+
+    return Result<UserSettings, std::string>::okay(response.value().settings);
+}
+
+Result<UserSettings, std::string> resetUserSettings(
+    Network::WebSocketService& serverClient, int timeoutMs)
+{
+    Api::UserSettingsReset::Command cmd{};
+    auto response = unwrapResponse(
+        serverClient.sendCommandAndGetResponse<Api::UserSettingsReset::Okay>(cmd, timeoutMs));
+    if (response.isError()) {
+        return Result<UserSettings, std::string>::error(
+            "UserSettingsReset failed: " + response.errorValue());
+    }
+
+    return Result<UserSettings, std::string>::okay(response.value().settings);
+}
+
+Result<std::monostate, std::string> waitForClockRenderTimezone(
+    Network::WebSocketService& serverClient, int expectedTimezoneIndex, int timeoutMs)
+{
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool matched = false;
+    std::optional<int> lastTimezoneIndex;
+    std::string parseError;
+
+    serverClient.onBinary([&](const std::vector<std::byte>& payload) {
+        try {
+            RenderMessageFull fullMessage;
+            zpp::bits::in in(payload);
+            in(fullMessage).or_throw();
+
+            if (fullMessage.scenario_id != Scenario::EnumType::Clock) {
+                return;
+            }
+
+            const auto* clockConfig = std::get_if<Config::Clock>(&fullMessage.scenario_config);
+            if (!clockConfig) {
+                return;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                lastTimezoneIndex = static_cast<int>(clockConfig->timezoneIndex);
+                matched = (lastTimezoneIndex.value() == expectedTimezoneIndex);
+            }
+
+            cv.notify_all();
+        }
+        catch (const std::exception& e) {
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                parseError = e.what();
+            }
+            cv.notify_all();
+        }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        while (!matched && parseError.empty()) {
+            if (cv.wait_until(lock, deadline) == std::cv_status::timeout) {
+                break;
+            }
+        }
+    }
+
+    serverClient.onBinary([](const std::vector<std::byte>& /*payload*/) {});
+
+    if (matched) {
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }
+
+    if (!parseError.empty()) {
+        return Result<std::monostate, std::string>::error(
+            "Failed to parse RenderMessage payload: " + parseError);
+    }
+
+    std::string detail = "did not receive Clock render config";
+    if (lastTimezoneIndex.has_value()) {
+        detail += ", last timezoneIndex=" + std::to_string(*lastTimezoneIndex);
+    }
+
+    return Result<std::monostate, std::string>::error(
+        "Timeout waiting for expected clock timezone (" + std::to_string(expectedTimezoneIndex)
+        + "): " + detail);
 }
 
 struct SeedTarget {
@@ -655,6 +883,28 @@ Result<std::monostate, std::string> restartServices(
     if (statusResult.isError()) {
         return Result<std::monostate, std::string>::error(
             "SystemStatus check failed: " + statusResult.errorValue());
+    }
+
+    return Result<std::monostate, std::string>::okay(std::monostate{});
+}
+
+Result<std::monostate, std::string> stopUiService(
+    const std::string& osManagerAddress, int timeoutMs)
+{
+    Network::WebSocketService client;
+    auto connectResult = client.connect(osManagerAddress, timeoutMs);
+    if (connectResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "Failed to connect to os-manager: " + connectResult.errorValue());
+    }
+
+    OsApi::StopUi::Command stopUiCmd{};
+    auto stopUiResult =
+        unwrapResponse(client.sendCommandAndGetResponse<std::monostate>(stopUiCmd, timeoutMs));
+    client.disconnect();
+    if (stopUiResult.isError()) {
+        return Result<std::monostate, std::string>::error(
+            "StopUi failed: " + stopUiResult.errorValue());
     }
 
     return Result<std::monostate, std::string>::okay(std::monostate{});
@@ -1521,6 +1771,646 @@ FunctionalTestSummary FunctionalTestRunner::runCanOpenTrainingConfigPanel(
 
     return FunctionalTestSummary{
         .name = "canOpenTrainingConfigPanel",
+        .duration_ms = durationMs,
+        .result = std::move(testResult),
+        .failure_screenshot_path = std::nullopt,
+        .training_summary = std::nullopt,
+    };
+}
+
+FunctionalTestSummary FunctionalTestRunner::runCanUpdateUserSettings(
+    const std::string& uiAddress,
+    const std::string& serverAddress,
+    const std::string& osManagerAddress,
+    int timeoutMs)
+{
+    const auto startTime = std::chrono::steady_clock::now();
+    Network::WebSocketService uiClient;
+    Network::WebSocketService serverClient;
+
+    auto testResult = [&]() -> Result<std::monostate, std::string> {
+        auto restartResult = restartServices(osManagerAddress, timeoutMs);
+        if (restartResult.isError()) {
+            return Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+
+        auto uiConnect = uiClient.connect(uiAddress, timeoutMs);
+        if (uiConnect.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "Failed to connect to UI: " + uiConnect.errorValue());
+        }
+
+        auto uiReadyResult = ensureUiInStartMenu(uiClient, timeoutMs);
+        if (uiReadyResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiReadyResult.errorValue());
+        }
+
+        auto serverConnectResult =
+            connectServerBinary(serverClient, serverAddress, timeoutMs, false);
+        if (serverConnectResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverConnectResult.errorValue());
+        }
+
+        auto serverIdleResult = ensureServerIdle(serverClient, timeoutMs);
+        if (serverIdleResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleResult.errorValue());
+        }
+
+        auto currentSettingsResult = fetchUserSettings(serverClient, timeoutMs);
+        if (currentSettingsResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(currentSettingsResult.errorValue());
+        }
+
+        UserSettings expected = currentSettingsResult.value();
+        expected.timezoneIndex = 0;
+        expected.volumePercent = 67;
+        expected.defaultScenario = Scenario::EnumType::Clock;
+
+        auto setResult = updateUserSettings(serverClient, expected, timeoutMs);
+        if (setResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(setResult.errorValue());
+        }
+
+        const UserSettings& updated = setResult.value();
+        if (updated.timezoneIndex != expected.timezoneIndex
+            || updated.volumePercent != expected.volumePercent
+            || updated.defaultScenario != expected.defaultScenario) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UserSettingsSet response does not match requested values");
+        }
+
+        auto verifyResult = fetchUserSettings(serverClient, timeoutMs);
+        if (verifyResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(verifyResult.errorValue());
+        }
+
+        const UserSettings& verified = verifyResult.value();
+        if (verified.timezoneIndex != expected.timezoneIndex
+            || verified.volumePercent != expected.volumePercent
+            || verified.defaultScenario != expected.defaultScenario) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UserSettingsGet did not reflect updated values");
+        }
+
+        uiClient.disconnect();
+        serverClient.disconnect();
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }();
+
+    auto restartResult = restartServices(osManagerAddress, timeoutMs);
+    if (restartResult.isError()) {
+        if (testResult.isError()) {
+            std::cerr << "Restart failed: " << restartResult.errorValue() << std::endl;
+        }
+        else {
+            testResult = Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+    }
+
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - startTime)
+                                .count();
+
+    return FunctionalTestSummary{
+        .name = "canUpdateUserSettings",
+        .duration_ms = durationMs,
+        .result = std::move(testResult),
+        .failure_screenshot_path = std::nullopt,
+        .training_summary = std::nullopt,
+    };
+}
+
+FunctionalTestSummary FunctionalTestRunner::runCanResetUserSettings(
+    const std::string& uiAddress,
+    const std::string& serverAddress,
+    const std::string& osManagerAddress,
+    int timeoutMs)
+{
+    const auto startTime = std::chrono::steady_clock::now();
+    Network::WebSocketService uiClient;
+    Network::WebSocketService serverClient;
+
+    auto testResult = [&]() -> Result<std::monostate, std::string> {
+        auto restartResult = restartServices(osManagerAddress, timeoutMs);
+        if (restartResult.isError()) {
+            return Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+
+        auto uiConnect = uiClient.connect(uiAddress, timeoutMs);
+        if (uiConnect.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "Failed to connect to UI: " + uiConnect.errorValue());
+        }
+
+        auto uiReadyResult = ensureUiInStartMenu(uiClient, timeoutMs);
+        if (uiReadyResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiReadyResult.errorValue());
+        }
+
+        auto serverConnectResult =
+            connectServerBinary(serverClient, serverAddress, timeoutMs, false);
+        if (serverConnectResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverConnectResult.errorValue());
+        }
+
+        auto serverIdleResult = ensureServerIdle(serverClient, timeoutMs);
+        if (serverIdleResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleResult.errorValue());
+        }
+
+        UserSettings changedSettings{};
+        changedSettings.timezoneIndex = 0;
+        changedSettings.volumePercent = 73;
+        changedSettings.defaultScenario = Scenario::EnumType::Clock;
+
+        auto setResult = updateUserSettings(serverClient, changedSettings, timeoutMs);
+        if (setResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(setResult.errorValue());
+        }
+
+        auto resetResult = resetUserSettings(serverClient, timeoutMs);
+        if (resetResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(resetResult.errorValue());
+        }
+
+        const UserSettings defaults{};
+        const UserSettings& reset = resetResult.value();
+        if (reset.timezoneIndex != defaults.timezoneIndex
+            || reset.volumePercent != defaults.volumePercent
+            || reset.defaultScenario != defaults.defaultScenario) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UserSettingsReset response did not return defaults");
+        }
+
+        auto verifyResult = fetchUserSettings(serverClient, timeoutMs);
+        if (verifyResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(verifyResult.errorValue());
+        }
+
+        const UserSettings& verified = verifyResult.value();
+        if (verified.timezoneIndex != defaults.timezoneIndex
+            || verified.volumePercent != defaults.volumePercent
+            || verified.defaultScenario != defaults.defaultScenario) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UserSettingsGet after reset did not return defaults");
+        }
+
+        uiClient.disconnect();
+        serverClient.disconnect();
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }();
+
+    auto restartResult = restartServices(osManagerAddress, timeoutMs);
+    if (restartResult.isError()) {
+        if (testResult.isError()) {
+            std::cerr << "Restart failed: " << restartResult.errorValue() << std::endl;
+        }
+        else {
+            testResult = Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+    }
+
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - startTime)
+                                .count();
+
+    return FunctionalTestSummary{
+        .name = "canResetUserSettings",
+        .duration_ms = durationMs,
+        .result = std::move(testResult),
+        .failure_screenshot_path = std::nullopt,
+        .training_summary = std::nullopt,
+    };
+}
+
+FunctionalTestSummary FunctionalTestRunner::runCanPersistUserSettingsAcrossRestart(
+    const std::string& uiAddress,
+    const std::string& serverAddress,
+    const std::string& osManagerAddress,
+    int timeoutMs)
+{
+    const auto startTime = std::chrono::steady_clock::now();
+    Network::WebSocketService uiClient;
+    Network::WebSocketService serverClient;
+
+    auto testResult = [&]() -> Result<std::monostate, std::string> {
+        auto restartResult = restartServices(osManagerAddress, timeoutMs);
+        if (restartResult.isError()) {
+            return Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+
+        auto uiConnect = uiClient.connect(uiAddress, timeoutMs);
+        if (uiConnect.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "Failed to connect to UI: " + uiConnect.errorValue());
+        }
+
+        auto uiReadyResult = ensureUiInStartMenu(uiClient, timeoutMs);
+        if (uiReadyResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiReadyResult.errorValue());
+        }
+
+        auto serverConnectResult =
+            connectServerBinary(serverClient, serverAddress, timeoutMs, false);
+        if (serverConnectResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverConnectResult.errorValue());
+        }
+
+        auto serverIdleResult = ensureServerIdle(serverClient, timeoutMs);
+        if (serverIdleResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleResult.errorValue());
+        }
+
+        UserSettings expected{};
+        expected.timezoneIndex = 1;
+        expected.volumePercent = 33;
+        expected.defaultScenario = Scenario::EnumType::TreeGermination;
+
+        auto setResult = updateUserSettings(serverClient, expected, timeoutMs);
+        if (setResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(setResult.errorValue());
+        }
+
+        auto verifyBeforeRestart = fetchUserSettings(serverClient, timeoutMs);
+        if (verifyBeforeRestart.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(verifyBeforeRestart.errorValue());
+        }
+
+        const UserSettings& beforeRestart = verifyBeforeRestart.value();
+        if (beforeRestart.timezoneIndex != expected.timezoneIndex
+            || beforeRestart.volumePercent != expected.volumePercent
+            || beforeRestart.defaultScenario != expected.defaultScenario) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UserSettings before restart do not match expected values");
+        }
+
+        uiClient.disconnect();
+        serverClient.disconnect();
+
+        auto midRestart = restartServices(osManagerAddress, timeoutMs);
+        if (midRestart.isError()) {
+            return Result<std::monostate, std::string>::error(midRestart.errorValue());
+        }
+
+        auto reconnectServer = connectServerBinary(serverClient, serverAddress, timeoutMs, false);
+        if (reconnectServer.isError()) {
+            return Result<std::monostate, std::string>::error(reconnectServer.errorValue());
+        }
+
+        auto verifyAfterRestart = fetchUserSettings(serverClient, timeoutMs);
+        if (verifyAfterRestart.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(verifyAfterRestart.errorValue());
+        }
+
+        const UserSettings& afterRestart = verifyAfterRestart.value();
+        if (afterRestart.timezoneIndex != expected.timezoneIndex
+            || afterRestart.volumePercent != expected.volumePercent
+            || afterRestart.defaultScenario != expected.defaultScenario) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "User settings did not persist across restart");
+        }
+
+        serverClient.disconnect();
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }();
+
+    auto restartResult = restartServices(osManagerAddress, timeoutMs);
+    if (restartResult.isError()) {
+        if (testResult.isError()) {
+            std::cerr << "Restart failed: " << restartResult.errorValue() << std::endl;
+        }
+        else {
+            testResult = Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+    }
+
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - startTime)
+                                .count();
+
+    return FunctionalTestSummary{
+        .name = "canPersistUserSettingsAcrossRestart",
+        .duration_ms = durationMs,
+        .result = std::move(testResult),
+        .failure_screenshot_path = std::nullopt,
+        .training_summary = std::nullopt,
+    };
+}
+
+FunctionalTestSummary FunctionalTestRunner::runCanUseDefaultScenarioWhenSimRunHasNoScenario(
+    const std::string& uiAddress,
+    const std::string& serverAddress,
+    const std::string& osManagerAddress,
+    int timeoutMs)
+{
+    const auto startTime = std::chrono::steady_clock::now();
+    Network::WebSocketService uiClient;
+    Network::WebSocketService serverClient;
+
+    auto testResult = [&]() -> Result<std::monostate, std::string> {
+        auto restartResult = restartServices(osManagerAddress, timeoutMs);
+        if (restartResult.isError()) {
+            return Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+
+        auto uiConnect = uiClient.connect(uiAddress, timeoutMs);
+        if (uiConnect.isError()) {
+            return Result<std::monostate, std::string>::error(
+                "Failed to connect to UI: " + uiConnect.errorValue());
+        }
+
+        auto uiReadyResult = ensureUiInStartMenu(uiClient, timeoutMs);
+        if (uiReadyResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiReadyResult.errorValue());
+        }
+
+        auto serverConnectResult =
+            connectServerBinary(serverClient, serverAddress, timeoutMs, false);
+        if (serverConnectResult.isError()) {
+            uiClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverConnectResult.errorValue());
+        }
+
+        auto serverIdleResult = ensureServerIdle(serverClient, timeoutMs);
+        if (serverIdleResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleResult.errorValue());
+        }
+
+        auto currentSettingsResult = fetchUserSettings(serverClient, timeoutMs);
+        if (currentSettingsResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(currentSettingsResult.errorValue());
+        }
+
+        UserSettings desired = currentSettingsResult.value();
+        desired.defaultScenario = Scenario::EnumType::Clock;
+
+        auto setResult = updateUserSettings(serverClient, desired, timeoutMs);
+        if (setResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(setResult.errorValue());
+        }
+
+        UiApi::SimRun::Command simRunCmd{};
+        auto simRunResult = unwrapResponse(
+            uiClient.sendCommandAndGetResponse<UiApi::SimRun::Okay>(simRunCmd, timeoutMs));
+        if (simRunResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UI SimRun (without scenario) failed: " + simRunResult.errorValue());
+        }
+
+        auto uiRunningResult = waitForUiState(uiClient, "SimRunning", timeoutMs);
+        if (uiRunningResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiRunningResult.errorValue());
+        }
+
+        auto serverRunningResult = waitForServerState(serverClient, "SimRunning", timeoutMs);
+        if (serverRunningResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverRunningResult.errorValue());
+        }
+
+        auto statusResult = requestServerStatus(serverClient, timeoutMs);
+        if (statusResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "Server StatusGet failed: " + statusResult.errorValue());
+        }
+
+        if (!statusResult.value().scenario_id.has_value()
+            || statusResult.value().scenario_id.value() != Scenario::EnumType::Clock) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "Server did not run user default scenario for SimRun without scenario_id");
+        }
+
+        UiApi::SimStop::Command simStopCmd{};
+        auto stopResult = unwrapResponse(
+            uiClient.sendCommandAndGetResponse<UiApi::SimStop::Okay>(simStopCmd, timeoutMs));
+        if (stopResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "UI SimStop failed: " + stopResult.errorValue());
+        }
+
+        auto uiStartMenuResult = waitForUiState(uiClient, "StartMenu", timeoutMs);
+        if (uiStartMenuResult.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(uiStartMenuResult.errorValue());
+        }
+
+        auto serverIdleAfterStop = waitForServerState(serverClient, "Idle", timeoutMs);
+        if (serverIdleAfterStop.isError()) {
+            uiClient.disconnect();
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleAfterStop.errorValue());
+        }
+
+        uiClient.disconnect();
+        serverClient.disconnect();
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }();
+
+    auto restartResult = restartServices(osManagerAddress, timeoutMs);
+    if (restartResult.isError()) {
+        if (testResult.isError()) {
+            std::cerr << "Restart failed: " << restartResult.errorValue() << std::endl;
+        }
+        else {
+            testResult = Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+    }
+
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - startTime)
+                                .count();
+
+    return FunctionalTestSummary{
+        .name = "canUseDefaultScenarioWhenSimRunHasNoScenario",
+        .duration_ms = durationMs,
+        .result = std::move(testResult),
+        .failure_screenshot_path = std::nullopt,
+        .training_summary = std::nullopt,
+    };
+}
+
+FunctionalTestSummary FunctionalTestRunner::runCanApplyClockTimezoneFromUserSettings(
+    const std::string& uiAddress,
+    const std::string& serverAddress,
+    const std::string& osManagerAddress,
+    int timeoutMs)
+{
+    const auto startTime = std::chrono::steady_clock::now();
+    Network::WebSocketService serverClient;
+    static_cast<void>(uiAddress);
+
+    auto testResult = [&]() -> Result<std::monostate, std::string> {
+        constexpr int expectedTimezoneIndex = 0;
+
+        auto restartResult = restartServices(osManagerAddress, timeoutMs);
+        if (restartResult.isError()) {
+            return Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+
+        auto stopUiResult = stopUiService(osManagerAddress, timeoutMs);
+        if (stopUiResult.isError()) {
+            return Result<std::monostate, std::string>::error(stopUiResult.errorValue());
+        }
+
+        auto serverConnectResult =
+            connectServerBinary(serverClient, serverAddress, timeoutMs, true);
+        if (serverConnectResult.isError()) {
+            return Result<std::monostate, std::string>::error(serverConnectResult.errorValue());
+        }
+
+        auto serverIdleResult = ensureServerIdle(serverClient, timeoutMs);
+        if (serverIdleResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleResult.errorValue());
+        }
+
+        Api::RenderFormatSet::Command renderCmd{
+            .format = RenderFormat::EnumType::Basic,
+            .connectionId = "",
+        };
+        auto renderResult =
+            unwrapResponse(serverClient.sendCommandAndGetResponse<Api::RenderFormatSet::Okay>(
+                renderCmd, timeoutMs));
+        if (renderResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "RenderFormatSet failed: " + renderResult.errorValue());
+        }
+
+        auto currentSettingsResult = fetchUserSettings(serverClient, timeoutMs);
+        if (currentSettingsResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(currentSettingsResult.errorValue());
+        }
+
+        UserSettings desired = currentSettingsResult.value();
+        desired.timezoneIndex = expectedTimezoneIndex;
+
+        auto setResult = updateUserSettings(serverClient, desired, timeoutMs);
+        if (setResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(setResult.errorValue());
+        }
+
+        Api::SimRun::Command simRunCmd{
+            .scenario_id = Scenario::EnumType::Clock,
+            .container_size = Vector2s(800, 480),
+        };
+        auto simRunResult = unwrapResponse(
+            serverClient.sendCommandAndGetResponse<Api::SimRun::Okay>(simRunCmd, timeoutMs));
+        if (simRunResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "Server SimRun (Clock) failed: " + simRunResult.errorValue());
+        }
+
+        auto serverRunningResult = waitForServerState(serverClient, "SimRunning", timeoutMs);
+        if (serverRunningResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverRunningResult.errorValue());
+        }
+
+        auto timezoneResult = waitForClockRenderTimezone(
+            serverClient, expectedTimezoneIndex, std::max(timeoutMs, 10000));
+        if (timezoneResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(timezoneResult.errorValue());
+        }
+
+        Api::SimStop::Command simStopCmd{};
+        auto stopResult = unwrapResponse(
+            serverClient.sendCommandAndGetResponse<Api::SimStop::OkayType>(simStopCmd, timeoutMs));
+        if (stopResult.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(
+                "Server SimStop failed: " + stopResult.errorValue());
+        }
+
+        auto serverIdleAfterStop = waitForServerState(serverClient, "Idle", timeoutMs);
+        if (serverIdleAfterStop.isError()) {
+            serverClient.disconnect();
+            return Result<std::monostate, std::string>::error(serverIdleAfterStop.errorValue());
+        }
+
+        serverClient.disconnect();
+        return Result<std::monostate, std::string>::okay(std::monostate{});
+    }();
+
+    auto restartResult = restartServices(osManagerAddress, timeoutMs);
+    if (restartResult.isError()) {
+        if (testResult.isError()) {
+            std::cerr << "Restart failed: " << restartResult.errorValue() << std::endl;
+        }
+        else {
+            testResult = Result<std::monostate, std::string>::error(restartResult.errorValue());
+        }
+    }
+
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - startTime)
+                                .count();
+
+    return FunctionalTestSummary{
+        .name = "canApplyClockTimezoneFromUserSettings",
         .duration_ms = durationMs,
         .result = std::move(testResult),
         .failure_screenshot_path = std::nullopt,

--- a/apps/src/cli/FunctionalTestRunner.h
+++ b/apps/src/cli/FunctionalTestRunner.h
@@ -69,6 +69,31 @@ public:
         const std::string& serverAddress,
         const std::string& osManagerAddress,
         int timeoutMs);
+    FunctionalTestSummary runCanUpdateUserSettings(
+        const std::string& uiAddress,
+        const std::string& serverAddress,
+        const std::string& osManagerAddress,
+        int timeoutMs);
+    FunctionalTestSummary runCanResetUserSettings(
+        const std::string& uiAddress,
+        const std::string& serverAddress,
+        const std::string& osManagerAddress,
+        int timeoutMs);
+    FunctionalTestSummary runCanPersistUserSettingsAcrossRestart(
+        const std::string& uiAddress,
+        const std::string& serverAddress,
+        const std::string& osManagerAddress,
+        int timeoutMs);
+    FunctionalTestSummary runCanUseDefaultScenarioWhenSimRunHasNoScenario(
+        const std::string& uiAddress,
+        const std::string& serverAddress,
+        const std::string& osManagerAddress,
+        int timeoutMs);
+    FunctionalTestSummary runCanApplyClockTimezoneFromUserSettings(
+        const std::string& uiAddress,
+        const std::string& serverAddress,
+        const std::string& osManagerAddress,
+        int timeoutMs);
     FunctionalTestSummary runCanPlaySynthKeys(
         const std::string& uiAddress,
         const std::string& serverAddress,

--- a/apps/src/cli/README.md
+++ b/apps/src/cli/README.md
@@ -221,6 +221,11 @@ Run a minimal UI/server workflow check against a running system:
 ./build-debug/bin/cli functional-test canSetGenerationsAndTrain
 ./build-debug/bin/cli functional-test canPlantTreeSeed
 ./build-debug/bin/cli functional-test canOpenTrainingConfigPanel
+./build-debug/bin/cli functional-test canUpdateUserSettings
+./build-debug/bin/cli functional-test canResetUserSettings
+./build-debug/bin/cli functional-test canPersistUserSettingsAcrossRestart
+./build-debug/bin/cli functional-test canUseDefaultScenarioWhenSimRunHasNoScenario
+./build-debug/bin/cli functional-test canApplyClockTimezoneFromUserSettings
 ./build-debug/bin/cli functional-test canPlaySynthKeys
 ./build-debug/bin/cli functional-test verifyTraining
 
@@ -248,6 +253,11 @@ Run a minimal UI/server workflow check against a running system:
 - For canSetGenerationsAndTrain: runs TrainingStart with max_generations=2, verifies the training result reports the expected completed/max generations.
 - For canPlantTreeSeed: starts Tree Germination, plants a seed via the UI API, and waits for tree_vision.
 - For canOpenTrainingConfigPanel: starts training, opens the Training config panel via UI API, and verifies UI still responds.
+- For canUpdateUserSettings: updates timezone/volume/default scenario via server UserSettings APIs and verifies with UserSettingsGet.
+- For canResetUserSettings: changes settings, runs UserSettingsReset, and verifies defaults are restored.
+- For canPersistUserSettingsAcrossRestart: updates settings, restarts services, and verifies settings persisted.
+- For canUseDefaultScenarioWhenSimRunHasNoScenario: sets default scenario and verifies UI SimRun (without scenario_id) uses it.
+- For canApplyClockTimezoneFromUserSettings: sets timezone, runs Clock scenario, and verifies pushed Clock config uses the setting.
 - For canPlaySynthKeys: opens the Synth screen and sends programmatic key presses via UI API, verifying state details.
 
 ### Network Mode

--- a/apps/src/cli/main.cpp
+++ b/apps/src/cli/main.cpp
@@ -527,6 +527,11 @@ std::string getExamplesHelp()
     examples += "  cli functional-test canPlantTreeSeed\n";
     examples += "  cli functional-test canLoadGenomeFromBrowser\n";
     examples += "  cli functional-test canOpenTrainingConfigPanel\n";
+    examples += "  cli functional-test canUpdateUserSettings\n";
+    examples += "  cli functional-test canResetUserSettings\n";
+    examples += "  cli functional-test canPersistUserSettingsAcrossRestart\n";
+    examples += "  cli functional-test canUseDefaultScenarioWhenSimRunHasNoScenario\n";
+    examples += "  cli functional-test canApplyClockTimezoneFromUserSettings\n";
     examples += "  cli functional-test canPlaySynthKeys\n";
     examples += "  cli functional-test verifyTraining\n";
     examples += "  cli functional-test canExit --ui-address ws://dirtsim.local:7070 "
@@ -1046,11 +1051,19 @@ int main(int argc, char** argv)
         if (testName != "canExit" && testName != "canTrain"
             && testName != "canSetGenerationsAndTrain" && testName != "canPlantTreeSeed"
             && testName != "canLoadGenomeFromBrowser" && testName != "canOpenTrainingConfigPanel"
-            && testName != "canPlaySynthKeys" && testName != "verifyTraining") {
+            && testName != "canUpdateUserSettings" && testName != "canResetUserSettings"
+            && testName != "canPersistUserSettingsAcrossRestart"
+            && testName != "canUseDefaultScenarioWhenSimRunHasNoScenario"
+            && testName != "canApplyClockTimezoneFromUserSettings" && testName != "canPlaySynthKeys"
+            && testName != "verifyTraining") {
             std::cerr << "Error: unknown functional test '" << testName << "'\n";
             std::cerr << "Valid tests: canExit, canTrain, canSetGenerationsAndTrain, "
                          "canPlantTreeSeed, canLoadGenomeFromBrowser, "
-                         "canOpenTrainingConfigPanel, canPlaySynthKeys, verifyTraining\n";
+                         "canOpenTrainingConfigPanel, canUpdateUserSettings, "
+                         "canResetUserSettings, canPersistUserSettingsAcrossRestart, "
+                         "canUseDefaultScenarioWhenSimRunHasNoScenario, "
+                         "canApplyClockTimezoneFromUserSettings, canPlaySynthKeys, "
+                         "verifyTraining\n";
             return 1;
         }
 
@@ -1095,17 +1108,37 @@ int main(int argc, char** argv)
             summary = runner.runCanOpenTrainingConfigPanel(
                 uiAddress, serverAddress, osManagerAddress, timeoutMs);
         }
+        else if (testName == "canUpdateUserSettings") {
+            summary = runner.runCanUpdateUserSettings(
+                uiAddress, serverAddress, osManagerAddress, timeoutMs);
+        }
+        else if (testName == "canResetUserSettings") {
+            summary = runner.runCanResetUserSettings(
+                uiAddress, serverAddress, osManagerAddress, timeoutMs);
+        }
+        else if (testName == "canPersistUserSettingsAcrossRestart") {
+            summary = runner.runCanPersistUserSettingsAcrossRestart(
+                uiAddress, serverAddress, osManagerAddress, timeoutMs);
+        }
+        else if (testName == "canUseDefaultScenarioWhenSimRunHasNoScenario") {
+            summary = runner.runCanUseDefaultScenarioWhenSimRunHasNoScenario(
+                uiAddress, serverAddress, osManagerAddress, timeoutMs);
+        }
+        else if (testName == "canApplyClockTimezoneFromUserSettings") {
+            summary = runner.runCanApplyClockTimezoneFromUserSettings(
+                uiAddress, serverAddress, osManagerAddress, timeoutMs);
+        }
         else if (testName == "canPlaySynthKeys") {
             summary =
                 runner.runCanPlaySynthKeys(uiAddress, serverAddress, osManagerAddress, timeoutMs);
         }
-        else if (testName == "verifyTraining") {
+        else if (testName == "canPlantTreeSeed") {
             summary =
-                runner.runVerifyTraining(uiAddress, serverAddress, osManagerAddress, timeoutMs);
+                runner.runCanPlantTreeSeed(uiAddress, serverAddress, osManagerAddress, timeoutMs);
         }
         else {
             summary =
-                runner.runCanPlantTreeSeed(uiAddress, serverAddress, osManagerAddress, timeoutMs);
+                runner.runVerifyTraining(uiAddress, serverAddress, osManagerAddress, timeoutMs);
         }
         if (summary.result.isError()) {
             auto screenshotResult = captureFailureScreenshot(uiAddress, timeoutMs, testName);

--- a/apps/src/server/Event.h
+++ b/apps/src/server/Event.h
@@ -39,6 +39,9 @@
 #include "api/TrainingResultSave.h"
 #include "api/TrainingResultSet.h"
 #include "api/TrainingStreamConfigSet.h"
+#include "api/UserSettingsGet.h"
+#include "api/UserSettingsReset.h"
+#include "api/UserSettingsSet.h"
 #include "api/WorldResize.h"
 #include "core/MaterialType.h"
 #include "core/SimulationStats.h"
@@ -452,6 +455,9 @@ public:
         DirtSim::Api::StateGet::Cwc,
         DirtSim::Api::StatusGet::Cwc,
         DirtSim::Api::TimerStatsGet::Cwc,
+        DirtSim::Api::UserSettingsGet::Cwc,
+        DirtSim::Api::UserSettingsReset::Cwc,
+        DirtSim::Api::UserSettingsSet::Cwc,
         DirtSim::Api::TrainingResultDiscard::Cwc,
         DirtSim::Api::TrainingResultDelete::Cwc,
         DirtSim::Api::TrainingResultSave::Cwc,

--- a/apps/src/server/StateMachine.cpp
+++ b/apps/src/server/StateMachine.cpp
@@ -3,6 +3,7 @@
 #include "EventProcessor.h"
 #include "ServerConfig.h"
 #include "TrainingResultRepository.h"
+#include "UserSettings.h"
 #include "api/PeersGet.h"
 #include "api/TrainingResult.h"
 #include "api/TrainingResultDelete.h"
@@ -10,6 +11,10 @@
 #include "api/TrainingResultList.h"
 #include "api/TrainingResultSet.h"
 #include "api/TrainingStreamConfigSet.h"
+#include "api/UserSettingsGet.h"
+#include "api/UserSettingsReset.h"
+#include "api/UserSettingsSet.h"
+#include "api/UserSettingsUpdated.h"
 #include "api/WebSocketAccessSet.h"
 #include "api/WebUiAccessSet.h"
 #include "core/LoggingChannels.h"
@@ -28,6 +33,7 @@
 #include "core/network/WebSocketService.h"
 #include "core/organisms/brains/Genome.h"
 #include "core/organisms/evolution/GenomeRepository.h"
+#include "core/scenarios/ClockScenario.h"
 #include "core/scenarios/Scenario.h"
 #include "core/scenarios/ScenarioRegistry.h"
 #include "network/CommandDeserializerJson.h"
@@ -39,7 +45,9 @@
 #include <cassert>
 #include <chrono>
 #include <ctime>
+#include <fstream>
 #include <mutex>
+#include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 #include <thread>
 #include <unistd.h>
@@ -67,6 +75,134 @@ std::filesystem::path getDefaultDataDir()
         home = "/tmp";
     }
     return std::filesystem::path(home) / ".dirtsim";
+}
+
+int getMaxTimezoneIndex()
+{
+    return static_cast<int>(ClockScenario::TIMEZONES.size()) - 1;
+}
+
+std::filesystem::path getUserSettingsPath(const std::filesystem::path& dataDir)
+{
+    return dataDir / "user_settings.json";
+}
+
+bool persistUserSettingsToDisk(
+    const std::filesystem::path& filePath, const UserSettings& userSettings)
+{
+    std::ofstream file(filePath);
+    if (!file.is_open()) {
+        LOG_ERROR(State, "Failed to open '{}' for writing user settings", filePath.string());
+        return false;
+    }
+
+    nlohmann::json json = userSettings;
+    file << json.dump(2) << "\n";
+    if (!file.good()) {
+        LOG_ERROR(State, "Failed to write user settings to '{}'", filePath.string());
+        return false;
+    }
+
+    return true;
+}
+
+UserSettings sanitizeUserSettings(
+    const UserSettings& input,
+    const ScenarioRegistry& registry,
+    bool& changed,
+    std::vector<std::string>& updates)
+{
+    UserSettings settings = input;
+    changed = false;
+
+    const auto recordUpdate = [&](const std::string& message) {
+        updates.push_back(message);
+        changed = true;
+    };
+
+    if (settings.timezoneIndex < 0) {
+        settings.timezoneIndex = 0;
+        recordUpdate("timezoneIndex clamped to 0");
+    }
+    else if (settings.timezoneIndex > getMaxTimezoneIndex()) {
+        settings.timezoneIndex = getMaxTimezoneIndex();
+        recordUpdate("timezoneIndex clamped to maximum timezone");
+    }
+
+    if (settings.volumePercent < 0) {
+        settings.volumePercent = 0;
+        recordUpdate("volumePercent clamped to 0");
+    }
+    else if (settings.volumePercent > 100) {
+        settings.volumePercent = 100;
+        recordUpdate("volumePercent clamped to 100");
+    }
+
+    if (!registry.getMetadata(settings.defaultScenario)) {
+        settings.defaultScenario = UserSettings{}.defaultScenario;
+        recordUpdate("defaultScenario reset to fallback scenario");
+    }
+
+    return settings;
+}
+
+UserSettings loadUserSettingsFromDisk(
+    const std::filesystem::path& filePath, const ScenarioRegistry& registry)
+{
+    const UserSettings defaults;
+
+    std::error_code createErr;
+    std::filesystem::create_directories(filePath.parent_path(), createErr);
+    if (createErr) {
+        LOG_WARN(
+            State,
+            "Failed to create user settings directory '{}': {}",
+            filePath.parent_path().string(),
+            createErr.message());
+    }
+
+    if (!std::filesystem::exists(filePath)) {
+        LOG_INFO(State, "User settings file missing, writing defaults to '{}'", filePath.string());
+        persistUserSettingsToDisk(filePath, defaults);
+        return defaults;
+    }
+
+    try {
+        std::ifstream file(filePath);
+        if (!file.is_open()) {
+            LOG_WARN(
+                State,
+                "Failed to open user settings file '{}', restoring defaults",
+                filePath.string());
+            persistUserSettingsToDisk(filePath, defaults);
+            return defaults;
+        }
+
+        nlohmann::json json;
+        file >> json;
+        UserSettings parsed = json.get<UserSettings>();
+
+        bool changed = false;
+        std::vector<std::string> updates;
+        UserSettings sanitized = sanitizeUserSettings(parsed, registry, changed, updates);
+        if (changed) {
+            for (const auto& update : updates) {
+                LOG_WARN(State, "User settings validation: {}", update);
+            }
+            persistUserSettingsToDisk(filePath, sanitized);
+        }
+
+        return sanitized;
+    }
+    catch (const std::exception& e) {
+        LOG_WARN(
+            State,
+            "Failed to parse user settings '{}': {}. Restoring defaults.",
+            filePath.string(),
+            e.what());
+        persistUserSettingsToDisk(filePath, defaults);
+        return defaults;
+    }
 }
 
 bool isMissingTimestamp(uint64_t timestamp)
@@ -126,10 +262,13 @@ void sortGenomeListEntries(
 
 struct StateMachine::Impl {
     EventProcessor eventProcessor_;
+    std::filesystem::path dataDir_;
     std::unique_ptr<GamepadManager> gamepadManager_;
     GenomeRepository genomeRepository_;
     TrainingResultRepository trainingResultRepository_;
     ScenarioRegistry scenarioRegistry_;
+    std::filesystem::path userSettingsPath_;
+    UserSettings userSettings_;
     SystemMetrics systemMetrics_;
     Timers timers_;
     std::unique_ptr<HttpServer> httpServer_;
@@ -149,28 +288,30 @@ struct StateMachine::Impl {
     mutable std::mutex trainingResultsMutex_;
 
     explicit Impl(const std::optional<std::filesystem::path>& dataDir)
-        : genomeRepository_(initGenomeRepository(dataDir)),
-          trainingResultRepository_(initTrainingResultRepository(dataDir)),
-          scenarioRegistry_(ScenarioRegistry::createDefault(genomeRepository_))
-    {}
+        : dataDir_(dataDir.value_or(getDefaultDataDir())),
+          genomeRepository_(initGenomeRepository(dataDir_)),
+          trainingResultRepository_(initTrainingResultRepository(dataDir_)),
+          scenarioRegistry_(ScenarioRegistry::createDefault(genomeRepository_)),
+          userSettingsPath_(getUserSettingsPath(dataDir_)),
+          userSettings_(loadUserSettingsFromDisk(userSettingsPath_, scenarioRegistry_))
+    {
+        LOG_INFO(State, "User settings file: {}", userSettingsPath_.string());
+    }
 
 private:
-    static GenomeRepository initGenomeRepository(
-        const std::optional<std::filesystem::path>& dataDir)
+    static GenomeRepository initGenomeRepository(const std::filesystem::path& dataDir)
     {
-        auto dir = dataDir.value_or(getDefaultDataDir());
-        std::filesystem::create_directories(dir);
-        auto dbPath = dir / "genomes.db";
+        std::filesystem::create_directories(dataDir);
+        auto dbPath = dataDir / "genomes.db";
         spdlog::info("GenomeRepository: Using database at {}", dbPath.string());
         return GenomeRepository(dbPath);
     }
 
     static TrainingResultRepository initTrainingResultRepository(
-        const std::optional<std::filesystem::path>& dataDir)
+        const std::filesystem::path& dataDir)
     {
-        auto dir = dataDir.value_or(getDefaultDataDir());
-        std::filesystem::create_directories(dir);
-        auto dbPath = dir / "training_results.db";
+        std::filesystem::create_directories(dataDir);
+        auto dbPath = dataDir / "training_results.db";
         spdlog::info("TrainingResultRepository: Using database at {}", dbPath.string());
         return TrainingResultRepository(dbPath);
     }
@@ -386,6 +527,9 @@ void StateMachine::setupWebSocketService(Network::WebSocketService& service)
         DISPATCH_JSON_CMD_WITH_RESP(Api::StateGet);
         DISPATCH_JSON_CMD_WITH_RESP(Api::StatusGet);
         DISPATCH_JSON_CMD_WITH_RESP(Api::TimerStatsGet);
+        DISPATCH_JSON_CMD_WITH_RESP(Api::UserSettingsGet);
+        DISPATCH_JSON_CMD_WITH_RESP(Api::UserSettingsReset);
+        DISPATCH_JSON_CMD_WITH_RESP(Api::UserSettingsSet);
         DISPATCH_JSON_CMD_WITH_RESP(Api::WebSocketAccessSet);
         DISPATCH_JSON_CMD_WITH_RESP(Api::WebUiAccessSet);
         DISPATCH_JSON_CMD_EMPTY(Api::WorldResize);
@@ -638,6 +782,12 @@ void StateMachine::setupWebSocketService(Network::WebSocketService& service)
         [this](Api::SpawnDirtBall::Cwc cwc) { queueEvent(cwc); });
     service.registerHandler<Api::TimerStatsGet::Cwc>(
         [this](Api::TimerStatsGet::Cwc cwc) { queueEvent(cwc); });
+    service.registerHandler<Api::UserSettingsGet::Cwc>(
+        [this](Api::UserSettingsGet::Cwc cwc) { queueEvent(cwc); });
+    service.registerHandler<Api::UserSettingsReset::Cwc>(
+        [this](Api::UserSettingsReset::Cwc cwc) { queueEvent(cwc); });
+    service.registerHandler<Api::UserSettingsSet::Cwc>(
+        [this](Api::UserSettingsSet::Cwc cwc) { queueEvent(cwc); });
     service.registerHandler<Api::TrainingResultDiscard::Cwc>(
         [this](Api::TrainingResultDiscard::Cwc cwc) { queueEvent(cwc); });
     service.registerHandler<Api::TrainingResultDelete::Cwc>(
@@ -718,6 +868,16 @@ GenomeRepository& StateMachine::getGenomeRepository()
 const GenomeRepository& StateMachine::getGenomeRepository() const
 {
     return pImpl->genomeRepository_;
+}
+
+UserSettings& StateMachine::getUserSettings()
+{
+    return pImpl->userSettings_;
+}
+
+const UserSettings& StateMachine::getUserSettings() const
+{
+    return pImpl->userSettings_;
 }
 
 void StateMachine::storeTrainingResult(const Api::TrainingResult& result)
@@ -1190,6 +1350,65 @@ void StateMachine::handleEvent(const Event& event)
         okay.renderEveryN = it->renderEveryN;
         okay.message = "Render stream config updated";
         cwc.sendResponse(Api::RenderStreamConfigSet::Response::okay(std::move(okay)));
+        return;
+    }
+
+    if (std::holds_alternative<Api::UserSettingsGet::Cwc>(event.getVariant())) {
+        const auto& cwc = std::get<Api::UserSettingsGet::Cwc>(event.getVariant());
+        Api::UserSettingsGet::Okay response{ .settings = pImpl->userSettings_ };
+        cwc.sendResponse(Api::UserSettingsGet::Response::okay(std::move(response)));
+        return;
+    }
+
+    if (std::holds_alternative<Api::UserSettingsSet::Cwc>(event.getVariant())) {
+        const auto& cwc = std::get<Api::UserSettingsSet::Cwc>(event.getVariant());
+
+        bool changed = false;
+        std::vector<std::string> updates;
+        const UserSettings sanitized =
+            sanitizeUserSettings(cwc.command.settings, pImpl->scenarioRegistry_, changed, updates);
+
+        if (!persistUserSettingsToDisk(pImpl->userSettingsPath_, sanitized)) {
+            cwc.sendResponse(
+                Api::UserSettingsSet::Response::error(ApiError("Failed to persist user settings")));
+            return;
+        }
+
+        if (changed) {
+            for (const auto& update : updates) {
+                LOG_WARN(State, "UserSettingsSet: {}", update);
+            }
+        }
+
+        pImpl->userSettings_ = sanitized;
+
+        Api::UserSettingsSet::Okay response{ .settings = pImpl->userSettings_ };
+        cwc.sendResponse(Api::UserSettingsSet::Response::okay(std::move(response)));
+
+        const Api::UserSettingsUpdated updateEvent{ .settings = pImpl->userSettings_ };
+        broadcastEventData(
+            Api::UserSettingsUpdated::name(), Network::serialize_payload(updateEvent));
+        return;
+    }
+
+    if (std::holds_alternative<Api::UserSettingsReset::Cwc>(event.getVariant())) {
+        const auto& cwc = std::get<Api::UserSettingsReset::Cwc>(event.getVariant());
+
+        const UserSettings defaults;
+        if (!persistUserSettingsToDisk(pImpl->userSettingsPath_, defaults)) {
+            cwc.sendResponse(
+                Api::UserSettingsReset::Response::error(
+                    ApiError("Failed to persist user settings")));
+            return;
+        }
+
+        pImpl->userSettings_ = defaults;
+        Api::UserSettingsReset::Okay response{ .settings = pImpl->userSettings_ };
+        cwc.sendResponse(Api::UserSettingsReset::Response::okay(std::move(response)));
+
+        const Api::UserSettingsUpdated updateEvent{ .settings = pImpl->userSettings_ };
+        broadcastEventData(
+            Api::UserSettingsUpdated::name(), Network::serialize_payload(updateEvent));
         return;
     }
 

--- a/apps/src/server/StateMachine.h
+++ b/apps/src/server/StateMachine.h
@@ -23,6 +23,7 @@ namespace DirtSim {
 class GamepadManager;
 class GenomeRepository;
 struct ServerConfig;
+struct UserSettings;
 struct WorldData;
 
 namespace Api {
@@ -96,6 +97,8 @@ public:
 
     GenomeRepository& getGenomeRepository();
     const GenomeRepository& getGenomeRepository() const;
+    UserSettings& getUserSettings();
+    const UserSettings& getUserSettings() const;
 
     void storeTrainingResult(const Api::TrainingResult& result);
 

--- a/apps/src/server/UserSettings.cpp
+++ b/apps/src/server/UserSettings.cpp
@@ -1,0 +1,16 @@
+#include "UserSettings.h"
+#include "core/ReflectSerializer.h"
+
+namespace DirtSim {
+
+void from_json(const nlohmann::json& j, UserSettings& settings)
+{
+    settings = ReflectSerializer::from_json<UserSettings>(j);
+}
+
+void to_json(nlohmann::json& j, const UserSettings& settings)
+{
+    j = ReflectSerializer::to_json(settings);
+}
+
+} // namespace DirtSim

--- a/apps/src/server/UserSettings.h
+++ b/apps/src/server/UserSettings.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "core/ScenarioId.h"
+#include <nlohmann/json_fwd.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+
+struct UserSettings {
+    int timezoneIndex = 2;
+    int volumePercent = 20;
+    Scenario::EnumType defaultScenario = Scenario::EnumType::Sandbox;
+
+    using serialize = zpp::bits::members<3>;
+};
+
+void from_json(const nlohmann::json& j, UserSettings& settings);
+void to_json(nlohmann::json& j, const UserSettings& settings);
+
+} // namespace DirtSim

--- a/apps/src/server/api/ApiCommand.h
+++ b/apps/src/server/api/ApiCommand.h
@@ -41,6 +41,9 @@
 #include "TrainingResultSave.h"
 #include "TrainingResultSet.h"
 #include "TrainingStreamConfigSet.h"
+#include "UserSettingsGet.h"
+#include "UserSettingsReset.h"
+#include "UserSettingsSet.h"
 #include "WebSocketAccessSet.h"
 #include "WebUiAccessSet.h"
 #include "WorldResize.h"
@@ -104,6 +107,9 @@ using ApiCommand = std::variant<
     Api::StateGet::Command,
     Api::StatusGet::Command,
     Api::TimerStatsGet::Command,
+    Api::UserSettingsGet::Command,
+    Api::UserSettingsReset::Command,
+    Api::UserSettingsSet::Command,
     Api::TrainingResultDiscard::Command,
     Api::TrainingResultDelete::Command,
     Api::TrainingResultGet::Command,

--- a/apps/src/server/api/UserSettingsGet.h
+++ b/apps/src/server/api/UserSettingsGet.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "ApiError.h"
+#include "ApiMacros.h"
+#include "core/CommandWithCallback.h"
+#include "core/Result.h"
+#include "server/UserSettings.h"
+#include <nlohmann/json.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace Api {
+namespace UserSettingsGet {
+
+DEFINE_API_NAME(UserSettingsGet);
+
+struct Okay;
+
+struct Command {
+    API_COMMAND();
+    API_JSON_SERIALIZABLE(Command);
+
+    using serialize = zpp::bits::members<0>;
+};
+
+struct Okay {
+    UserSettings settings;
+
+    API_COMMAND_NAME();
+    API_JSON_SERIALIZABLE(Okay);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+using Response = Result<Okay, ApiError>;
+using Cwc = CommandWithCallback<Command, Response>;
+
+} // namespace UserSettingsGet
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/api/UserSettingsReset.h
+++ b/apps/src/server/api/UserSettingsReset.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "ApiError.h"
+#include "ApiMacros.h"
+#include "core/CommandWithCallback.h"
+#include "core/Result.h"
+#include "server/UserSettings.h"
+#include <nlohmann/json.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace Api {
+namespace UserSettingsReset {
+
+DEFINE_API_NAME(UserSettingsReset);
+
+struct Okay;
+
+struct Command {
+    API_COMMAND();
+    API_JSON_SERIALIZABLE(Command);
+
+    using serialize = zpp::bits::members<0>;
+};
+
+struct Okay {
+    UserSettings settings;
+
+    API_COMMAND_NAME();
+    API_JSON_SERIALIZABLE(Okay);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+using Response = Result<Okay, ApiError>;
+using Cwc = CommandWithCallback<Command, Response>;
+
+} // namespace UserSettingsReset
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/api/UserSettingsSet.cpp
+++ b/apps/src/server/api/UserSettingsSet.cpp
@@ -1,0 +1,43 @@
+#include "UserSettingsSet.h"
+#include "core/ReflectSerializer.h"
+#include <array>
+#include <stdexcept>
+
+namespace DirtSim {
+namespace Api {
+namespace UserSettingsSet {
+
+namespace {
+
+constexpr std::array<const char*, 3> kRequiredSettingsFields = {
+    "timezoneIndex",
+    "volumePercent",
+    "defaultScenario",
+};
+
+} // namespace
+
+nlohmann::json Command::toJson() const
+{
+    return ReflectSerializer::to_json(*this);
+}
+
+Command Command::fromJson(const nlohmann::json& j)
+{
+    if (!j.contains("settings") || !j["settings"].is_object()) {
+        throw std::runtime_error("settings object is required");
+    }
+
+    const auto& settingsJson = j["settings"];
+    for (const char* field : kRequiredSettingsFields) {
+        if (!settingsJson.contains(field)) {
+            throw std::runtime_error(std::string("settings.") + field + " is required");
+        }
+    }
+
+    return ReflectSerializer::from_json<Command>(j);
+}
+
+} // namespace UserSettingsSet
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/api/UserSettingsSet.h
+++ b/apps/src/server/api/UserSettingsSet.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ApiError.h"
+#include "ApiMacros.h"
+#include "core/CommandWithCallback.h"
+#include "core/Result.h"
+#include "server/UserSettings.h"
+#include <nlohmann/json.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace Api {
+namespace UserSettingsSet {
+
+DEFINE_API_NAME(UserSettingsSet);
+
+struct Okay;
+
+struct Command {
+    UserSettings settings;
+
+    API_COMMAND();
+    nlohmann::json toJson() const;
+    static Command fromJson(const nlohmann::json& j);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+struct Okay {
+    UserSettings settings;
+
+    API_COMMAND_NAME();
+    API_JSON_SERIALIZABLE(Okay);
+
+    using serialize = zpp::bits::members<1>;
+};
+
+using Response = Result<Okay, ApiError>;
+using Cwc = CommandWithCallback<Command, Response>;
+
+} // namespace UserSettingsSet
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/api/UserSettingsUpdated.cpp
+++ b/apps/src/server/api/UserSettingsUpdated.cpp
@@ -1,0 +1,13 @@
+#include "UserSettingsUpdated.h"
+#include "core/ReflectSerializer.h"
+
+namespace DirtSim {
+namespace Api {
+
+nlohmann::json UserSettingsUpdated::toJson() const
+{
+    return ReflectSerializer::to_json(*this);
+}
+
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/api/UserSettingsUpdated.h
+++ b/apps/src/server/api/UserSettingsUpdated.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "server/UserSettings.h"
+#include <nlohmann/json.hpp>
+#include <zpp_bits.h>
+
+namespace DirtSim {
+namespace Api {
+
+struct UserSettingsUpdated {
+    UserSettings settings;
+
+    nlohmann::json toJson() const;
+    static constexpr const char* name() { return "UserSettingsUpdated"; }
+
+    using serialize = zpp::bits::members<1>;
+};
+
+} // namespace Api
+} // namespace DirtSim

--- a/apps/src/server/network/CommandDeserializerJson.cpp
+++ b/apps/src/server/network/CommandDeserializerJson.cpp
@@ -31,6 +31,9 @@
 #include "server/api/TrainingResultSave.h"
 #include "server/api/TrainingResultSet.h"
 #include "server/api/TrainingStreamConfigSet.h"
+#include "server/api/UserSettingsGet.h"
+#include "server/api/UserSettingsReset.h"
+#include "server/api/UserSettingsSet.h"
 #include "server/api/WebUiAccessSet.h"
 #include <cctype>
 #include <spdlog/spdlog.h>
@@ -147,6 +150,16 @@ Result<ApiCommand, ApiError> CommandDeserializerJson::deserialize(const std::str
         }
         else if (commandName == Api::TimerStatsGet::Command::name()) {
             return Result<ApiCommand, ApiError>::okay(Api::TimerStatsGet::Command::fromJson(cmd));
+        }
+        else if (commandName == Api::UserSettingsGet::Command::name()) {
+            return Result<ApiCommand, ApiError>::okay(Api::UserSettingsGet::Command::fromJson(cmd));
+        }
+        else if (commandName == Api::UserSettingsReset::Command::name()) {
+            return Result<ApiCommand, ApiError>::okay(
+                Api::UserSettingsReset::Command::fromJson(cmd));
+        }
+        else if (commandName == Api::UserSettingsSet::Command::name()) {
+            return Result<ApiCommand, ApiError>::okay(Api::UserSettingsSet::Command::fromJson(cmd));
         }
         else if (commandName == Api::TrainingResultDiscard::Command::name()) {
             return Result<ApiCommand, ApiError>::okay(

--- a/apps/src/server/states/Idle.cpp
+++ b/apps/src/server/states/Idle.cpp
@@ -7,11 +7,13 @@
 #include "core/organisms/evolution/GenomeRepository.h"
 #include "core/organisms/evolution/TrainingBrainRegistry.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "core/scenarios/ClockScenario.h"
 #include "core/scenarios/ScenarioRegistry.h"
 #include "server/ServerConfig.h"
 #include "server/StateMachine.h"
 #include "server/api/ApiError.h"
 #include "server/network/PeerDiscovery.h"
+#include <algorithm>
 #include <thread>
 
 namespace DirtSim {
@@ -19,6 +21,23 @@ namespace Server {
 namespace State {
 
 namespace {
+
+ScenarioConfig buildScenarioConfigForRun(StateMachine& dsm, Scenario::EnumType scenarioId)
+{
+    ScenarioConfig scenarioConfig = makeDefaultConfig(scenarioId);
+    if (dsm.serverConfig && getScenarioId(dsm.serverConfig->startupConfig) == scenarioId) {
+        scenarioConfig = dsm.serverConfig->startupConfig;
+    }
+
+    if (auto* clockConfig = std::get_if<Config::Clock>(&scenarioConfig)) {
+        clockConfig->timezoneIndex = static_cast<uint8_t>(std::clamp(
+            dsm.getUserSettings().timezoneIndex,
+            0,
+            static_cast<int>(ClockScenario::TIMEZONES.size()) - 1));
+    }
+
+    return scenarioConfig;
+}
 
 std::optional<ApiError> validateTrainingConfig(
     const Api::EvolutionStart::Command& command,
@@ -212,10 +231,10 @@ State::Any Idle::onEvent(const Api::SimRun::Cwc& cwc, StateMachine& dsm)
 {
     assert(dsm.serverConfig && "serverConfig must be loaded");
 
-    // Use scenario_id from command if provided, otherwise fall back to server config.
+    // Use scenario_id from command if provided, otherwise fall back to user settings.
     Scenario::EnumType scenarioId = cwc.command.scenario_id.has_value()
         ? cwc.command.scenario_id.value()
-        : getScenarioId(dsm.serverConfig->startupConfig);
+        : dsm.getUserSettings().defaultScenario;
     LOG_INFO(State, "SimRun command received, using scenario '{}'", toString(scenarioId));
 
     // Validate max_frame_ms parameter.
@@ -275,8 +294,9 @@ State::Any Idle::onEvent(const Api::SimRun::Cwc& cwc, StateMachine& dsm)
     // Set scenario ID in state.
     newState.scenario_id = scenarioId;
 
-    // Apply config from server.json.
-    newState.scenario->setConfig(dsm.serverConfig->startupConfig, *newState.world);
+    // Apply config from server settings and user settings.
+    const ScenarioConfig scenarioConfig = buildScenarioConfigForRun(dsm, scenarioId);
+    newState.scenario->setConfig(scenarioConfig, *newState.world);
 
     // Run scenario setup to initialize world.
     newState.scenario->setup(*newState.world);

--- a/apps/src/server/tests/UserSettings_test.cpp
+++ b/apps/src/server/tests/UserSettings_test.cpp
@@ -1,0 +1,118 @@
+#include "server/Event.h"
+#include "server/UserSettings.h"
+#include "server/api/UserSettingsReset.h"
+#include "server/api/UserSettingsSet.h"
+#include "server/tests/TestStateMachineFixture.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using namespace DirtSim;
+using namespace DirtSim::Server;
+using namespace DirtSim::Server::Tests;
+
+namespace {
+
+UserSettings readUserSettingsFromDisk(const std::filesystem::path& path)
+{
+    std::ifstream file(path);
+    EXPECT_TRUE(file.is_open()) << "Failed to open user settings file: " << path;
+
+    nlohmann::json json;
+    file >> json;
+    return json.get<UserSettings>();
+}
+
+} // namespace
+
+TEST(UserSettingsTest, MissingFileLoadsDefaultsAndWritesFile)
+{
+    TestStateMachineFixture fixture("dirtsim-user-settings-defaults");
+
+    const std::filesystem::path settingsPath = fixture.testDataDir / "user_settings.json";
+    ASSERT_TRUE(std::filesystem::exists(settingsPath));
+
+    const UserSettings& inMemory = fixture.stateMachine->getUserSettings();
+    EXPECT_EQ(inMemory.timezoneIndex, 2);
+    EXPECT_EQ(inMemory.volumePercent, 20);
+    EXPECT_EQ(inMemory.defaultScenario, Scenario::EnumType::Sandbox);
+
+    const UserSettings fromDisk = readUserSettingsFromDisk(settingsPath);
+    EXPECT_EQ(fromDisk.timezoneIndex, 2);
+    EXPECT_EQ(fromDisk.volumePercent, 20);
+    EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Sandbox);
+}
+
+TEST(UserSettingsTest, UserSettingsSetClampsAndPersists)
+{
+    TestStateMachineFixture fixture("dirtsim-user-settings-set");
+
+    bool callbackInvoked = false;
+    Api::UserSettingsSet::Response response;
+
+    Api::UserSettingsSet::Command command{
+        .settings =
+            UserSettings{
+                .timezoneIndex = -50,
+                .volumePercent = 999,
+                .defaultScenario = Scenario::EnumType::Clock,
+            },
+    };
+    Api::UserSettingsSet::Cwc cwc(command, [&](Api::UserSettingsSet::Response&& result) {
+        callbackInvoked = true;
+        response = std::move(result);
+    });
+
+    fixture.stateMachine->handleEvent(Event{ cwc });
+
+    ASSERT_TRUE(callbackInvoked);
+    ASSERT_TRUE(response.isValue());
+    EXPECT_EQ(response.value().settings.timezoneIndex, 0);
+    EXPECT_EQ(response.value().settings.volumePercent, 100);
+    EXPECT_EQ(response.value().settings.defaultScenario, Scenario::EnumType::Clock);
+
+    const std::filesystem::path settingsPath = fixture.testDataDir / "user_settings.json";
+    const UserSettings fromDisk = readUserSettingsFromDisk(settingsPath);
+    EXPECT_EQ(fromDisk.timezoneIndex, 0);
+    EXPECT_EQ(fromDisk.volumePercent, 100);
+    EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Clock);
+}
+
+TEST(UserSettingsTest, UserSettingsResetRestoresDefaultsAndPersists)
+{
+    TestStateMachineFixture fixture("dirtsim-user-settings-reset");
+
+    Api::UserSettingsSet::Command setCommand{
+        .settings =
+            UserSettings{
+                .timezoneIndex = 7,
+                .volumePercent = 65,
+                .defaultScenario = Scenario::EnumType::Clock,
+            },
+    };
+    Api::UserSettingsSet::Cwc setCwc(setCommand, [](Api::UserSettingsSet::Response&&) {});
+    fixture.stateMachine->handleEvent(Event{ setCwc });
+
+    bool callbackInvoked = false;
+    Api::UserSettingsReset::Response response;
+    Api::UserSettingsReset::Command resetCommand{};
+    Api::UserSettingsReset::Cwc resetCwc(
+        resetCommand, [&](Api::UserSettingsReset::Response&& result) {
+            callbackInvoked = true;
+            response = std::move(result);
+        });
+
+    fixture.stateMachine->handleEvent(Event{ resetCwc });
+
+    ASSERT_TRUE(callbackInvoked);
+    ASSERT_TRUE(response.isValue());
+    EXPECT_EQ(response.value().settings.timezoneIndex, 2);
+    EXPECT_EQ(response.value().settings.volumePercent, 20);
+    EXPECT_EQ(response.value().settings.defaultScenario, Scenario::EnumType::Sandbox);
+
+    const std::filesystem::path settingsPath = fixture.testDataDir / "user_settings.json";
+    const UserSettings fromDisk = readUserSettingsFromDisk(settingsPath);
+    EXPECT_EQ(fromDisk.timezoneIndex, 2);
+    EXPECT_EQ(fromDisk.volumePercent, 20);
+    EXPECT_EQ(fromDisk.defaultScenario, Scenario::EnumType::Sandbox);
+}

--- a/apps/src/ui/SimPlayground.cpp
+++ b/apps/src/ui/SimPlayground.cpp
@@ -115,6 +115,7 @@ void SimPlayground::showPanelContent(IconId panelId)
         case IconId::TREE:
         case IconId::GENOME_BROWSER:
         case IconId::TRAINING_RESULTS:
+        case IconId::SETTINGS:
         case IconId::NONE:
             DIRTSIM_ASSERT(false, "Unexpected icon selection in SimRunning state");
             return;

--- a/apps/src/ui/controls/IconRail.cpp
+++ b/apps/src/ui/controls/IconRail.cpp
@@ -33,6 +33,7 @@ IconRail::IconRail(lv_obj_t* parent, EventSink* eventSink, FractalAnimator* frac
     iconConfigs_ = {
         { IconId::DUCK, "", "Start Menu", 0xFFD166 },                          // Duck yellow.
         { IconId::CORE, IconFont::HOME, "Core Controls", 0x87CEEB },           // Light blue.
+        { IconId::SETTINGS, IconFont::COG, "Settings", 0xA0A0A0 },             // Silver gray.
         { IconId::MUSIC, IconFont::WAVE_SQUARE, "Synth", 0x00B4D8 },           // Sky blue.
         { IconId::EVOLUTION, IconFont::CHART_LINE, "Evolution", 0xDA70D6 },    // Orchid/purple.
         { IconId::GENOME_BROWSER, IconFont::DNA, "Genome Browser", 0x40E0D0 }, // Turquoise.

--- a/apps/src/ui/controls/IconRail.h
+++ b/apps/src/ui/controls/IconRail.h
@@ -28,7 +28,8 @@ enum class IconId {
     GENOME_BROWSER = 8,
     TRAINING_RESULTS = 9,
     MUSIC = 10,
-    DUCK = 11
+    DUCK = 11,
+    SETTINGS = 12
 };
 
 enum class RailMode {

--- a/apps/src/ui/controls/StartMenuSettingsPanel.cpp
+++ b/apps/src/ui/controls/StartMenuSettingsPanel.cpp
@@ -1,0 +1,502 @@
+#include "StartMenuSettingsPanel.h"
+#include "core/LoggingChannels.h"
+#include "core/network/WebSocketServiceInterface.h"
+#include "core/scenarios/ClockScenario.h"
+#include "server/api/UserSettingsGet.h"
+#include "server/api/UserSettingsReset.h"
+#include "server/api/UserSettingsSet.h"
+#include "ui/PanelViewController.h"
+#include "ui/ScenarioMetadataCache.h"
+#include "ui/state-machine/Event.h"
+#include "ui/state-machine/EventSink.h"
+#include "ui/ui_builders/LVGLBuilder.h"
+#include <algorithm>
+#include <string>
+
+namespace DirtSim {
+namespace Ui {
+
+namespace {
+
+void setActionButtonText(lv_obj_t* buttonContainer, const std::string& text)
+{
+    if (!buttonContainer) {
+        return;
+    }
+
+    lv_obj_t* button = lv_obj_get_child(buttonContainer, 0);
+    if (!button) {
+        return;
+    }
+
+    const uint32_t childCount = lv_obj_get_child_cnt(button);
+    if (childCount == 0) {
+        return;
+    }
+
+    // Action buttons with icons have icon label first, then text label.
+    const uint32_t textIndex = childCount > 1 ? 1 : 0;
+    lv_obj_t* label = lv_obj_get_child(button, textIndex);
+    if (!label) {
+        return;
+    }
+
+    lv_label_set_text(label, text.c_str());
+}
+
+void setControlEnabled(lv_obj_t* control, bool enabled)
+{
+    if (!control) {
+        return;
+    }
+
+    if (enabled) {
+        lv_obj_clear_state(control, LV_STATE_DISABLED);
+        lv_obj_set_style_opa(control, LV_OPA_COVER, 0);
+        return;
+    }
+
+    lv_obj_add_state(control, LV_STATE_DISABLED);
+    lv_obj_set_style_opa(control, LV_OPA_50, 0);
+}
+
+} // namespace
+
+StartMenuSettingsPanel::StartMenuSettingsPanel(
+    lv_obj_t* container, Network::WebSocketServiceInterface* wsService, EventSink& eventSink)
+    : container_(container), wsService_(wsService), eventSink_(eventSink)
+{
+    viewController_ = std::make_unique<PanelViewController>(container_);
+
+    lv_obj_t* mainView = viewController_->createView("main");
+    createMainView(mainView);
+
+    lv_obj_t* timezoneView = viewController_->createView("timezone");
+    createTimezoneSelectionView(timezoneView);
+
+    lv_obj_t* scenarioView = viewController_->createView("scenario");
+    createScenarioSelectionView(scenarioView);
+
+    viewController_->showView("main");
+
+    updateTimezoneButtonText();
+    updateDefaultScenarioButtonText();
+    updateResetButtonEnabled();
+
+    LOG_INFO(Controls, "StartMenuSettingsPanel created");
+}
+
+StartMenuSettingsPanel::~StartMenuSettingsPanel()
+{
+    LOG_INFO(Controls, "StartMenuSettingsPanel destroyed");
+}
+
+void StartMenuSettingsPanel::createMainView(lv_obj_t* view)
+{
+    if (!view) {
+        return;
+    }
+
+    auto createRow = [view]() {
+        lv_obj_t* row = lv_obj_create(view);
+        lv_obj_set_size(row, LV_PCT(95), LV_SIZE_CONTENT);
+        lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
+        lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(row, 0, 0);
+        lv_obj_set_style_pad_all(row, 0, 0);
+        lv_obj_set_style_pad_column(row, 8, 0);
+        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+        return row;
+    };
+
+    lv_obj_t* resetRow = createRow();
+    resetButton_ = LVGLBuilder::actionButton(resetRow)
+                       .text("Reset")
+                       .mode(LVGLBuilder::ActionMode::Push)
+                       .width(120)
+                       .height(LVGLBuilder::Style::ACTION_SIZE)
+                       .layoutRow()
+                       .alignLeft()
+                       .backgroundColor(0xCC0000)
+                       .callback(onResetClicked, this)
+                       .buildOrLog();
+
+    resetConfirmCheckbox_ = lv_checkbox_create(resetRow);
+    lv_checkbox_set_text(resetConfirmCheckbox_, "Confirm");
+    lv_obj_set_style_text_font(resetConfirmCheckbox_, &lv_font_montserrat_12, 0);
+    lv_obj_clear_flag(resetConfirmCheckbox_, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_opa(resetConfirmCheckbox_, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(resetConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_all(resetConfirmCheckbox_, 0, 0);
+    lv_obj_set_style_pad_column(resetConfirmCheckbox_, 8, 0);
+    lv_obj_add_event_cb(resetConfirmCheckbox_, onResetConfirmToggled, LV_EVENT_VALUE_CHANGED, this);
+
+    timezoneButton_ = LVGLBuilder::actionButton(view)
+                          .text("Timezone")
+                          .icon(LV_SYMBOL_RIGHT)
+                          .width(LV_PCT(95))
+                          .height(LVGLBuilder::Style::ACTION_SIZE)
+                          .layoutRow()
+                          .alignLeft()
+                          .callback(onTimezoneButtonClicked, this)
+                          .buildOrLog();
+
+    volumeStepper_ = LVGLBuilder::actionStepper(view)
+                         .label("Volume")
+                         .range(0, 100)
+                         .step(1)
+                         .value(settings_.volumePercent)
+                         .valueFormat("%.0f")
+                         .valueScale(1.0)
+                         .width(LV_PCT(95))
+                         .callback(onVolumeChanged, this)
+                         .buildOrLog();
+
+    defaultScenarioButton_ = LVGLBuilder::actionButton(view)
+                                 .text("Default Scenario")
+                                 .icon(LV_SYMBOL_RIGHT)
+                                 .width(LV_PCT(95))
+                                 .height(LVGLBuilder::Style::ACTION_SIZE)
+                                 .layoutRow()
+                                 .alignLeft()
+                                 .callback(onDefaultScenarioButtonClicked, this)
+                                 .buildOrLog();
+}
+
+void StartMenuSettingsPanel::createScenarioSelectionView(lv_obj_t* view)
+{
+    if (!view) {
+        return;
+    }
+
+    LVGLBuilder::actionButton(view)
+        .text("Back")
+        .icon(LV_SYMBOL_LEFT)
+        .width(LV_PCT(95))
+        .height(LVGLBuilder::Style::ACTION_SIZE)
+        .layoutRow()
+        .alignLeft()
+        .callback(onBackToMainClicked, this)
+        .buildOrLog();
+
+    lv_obj_t* titleLabel = lv_label_create(view);
+    lv_label_set_text(titleLabel, "Default Scenario");
+    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_pad_top(titleLabel, 8, 0);
+    lv_obj_set_style_pad_bottom(titleLabel, 4, 0);
+
+    buttonToScenarioIndex_.clear();
+    if (!ScenarioMetadataCache::hasScenarios()) {
+        lv_obj_t* emptyLabel = lv_label_create(view);
+        lv_label_set_text(emptyLabel, "No scenarios loaded.");
+        lv_obj_set_style_text_color(emptyLabel, lv_color_hex(0xBBBBBB), 0);
+        lv_obj_set_style_text_font(emptyLabel, &lv_font_montserrat_14, 0);
+        return;
+    }
+    const std::vector<std::string> options = ScenarioMetadataCache::buildOptionsList();
+
+    for (size_t i = 0; i < options.size(); ++i) {
+        lv_obj_t* container = LVGLBuilder::actionButton(view)
+                                  .text(options[i].c_str())
+                                  .width(LV_PCT(95))
+                                  .height(LVGLBuilder::Style::ACTION_SIZE)
+                                  .layoutColumn()
+                                  .buildOrLog();
+        if (!container) {
+            continue;
+        }
+
+        lv_obj_t* button = lv_obj_get_child(container, 0);
+        if (!button) {
+            continue;
+        }
+
+        buttonToScenarioIndex_[button] = static_cast<int>(i);
+        lv_obj_add_event_cb(button, onDefaultScenarioSelected, LV_EVENT_CLICKED, this);
+    }
+}
+
+void StartMenuSettingsPanel::createTimezoneSelectionView(lv_obj_t* view)
+{
+    if (!view) {
+        return;
+    }
+
+    LVGLBuilder::actionButton(view)
+        .text("Back")
+        .icon(LV_SYMBOL_LEFT)
+        .width(LV_PCT(95))
+        .height(LVGLBuilder::Style::ACTION_SIZE)
+        .layoutRow()
+        .alignLeft()
+        .callback(onBackToMainClicked, this)
+        .buildOrLog();
+
+    lv_obj_t* titleLabel = lv_label_create(view);
+    lv_label_set_text(titleLabel, "Timezone");
+    lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_pad_top(titleLabel, 8, 0);
+    lv_obj_set_style_pad_bottom(titleLabel, 4, 0);
+
+    buttonToTimezoneIndex_.clear();
+    for (size_t i = 0; i < ClockScenario::TIMEZONES.size(); ++i) {
+        lv_obj_t* container = LVGLBuilder::actionButton(view)
+                                  .text(ClockScenario::TIMEZONES[i].label)
+                                  .width(LV_PCT(95))
+                                  .height(LVGLBuilder::Style::ACTION_SIZE)
+                                  .layoutColumn()
+                                  .buildOrLog();
+        if (!container) {
+            continue;
+        }
+
+        lv_obj_t* button = lv_obj_get_child(container, 0);
+        if (!button) {
+            continue;
+        }
+
+        buttonToTimezoneIndex_[button] = static_cast<int>(i);
+        lv_obj_add_event_cb(button, onTimezoneSelected, LV_EVENT_CLICKED, this);
+    }
+}
+
+void StartMenuSettingsPanel::refreshFromServer()
+{
+    if (!wsService_ || !wsService_->isConnected()) {
+        LOG_WARN(Controls, "StartMenuSettingsPanel: Cannot refresh settings, server disconnected");
+        return;
+    }
+
+    Api::UserSettingsGet::Command cmd{};
+    const auto result =
+        wsService_->sendCommandAndGetResponse<Api::UserSettingsGet::Okay>(cmd, 1000);
+    if (result.isError()) {
+        LOG_WARN(Controls, "UserSettingsGet failed: {}", result.errorValue());
+        return;
+    }
+
+    if (result.value().isError()) {
+        LOG_WARN(Controls, "UserSettingsGet error: {}", result.value().errorValue().message);
+        return;
+    }
+
+    eventSink_.queueEvent(UserSettingsUpdatedEvent{ .settings = result.value().value().settings });
+}
+
+void StartMenuSettingsPanel::applySettings(const DirtSim::UserSettings& settings)
+{
+    updatingUi_ = true;
+    settings_ = settings;
+
+    if (volumeStepper_) {
+        LVGLBuilder::ActionStepperBuilder::setValue(volumeStepper_, settings_.volumePercent);
+    }
+
+    if (resetConfirmCheckbox_) {
+        lv_obj_clear_state(resetConfirmCheckbox_, LV_STATE_CHECKED);
+    }
+
+    updateTimezoneButtonText();
+    updateDefaultScenarioButtonText();
+    updateResetButtonEnabled();
+
+    updatingUi_ = false;
+}
+
+void StartMenuSettingsPanel::sendSettingsUpdate()
+{
+    if (!wsService_ || !wsService_->isConnected()) {
+        LOG_WARN(
+            Controls, "StartMenuSettingsPanel: Cannot send settings update, server disconnected");
+        return;
+    }
+
+    Api::UserSettingsSet::Command cmd{ .settings = settings_ };
+    const auto result =
+        wsService_->sendCommandAndGetResponse<Api::UserSettingsSet::Okay>(cmd, 1000);
+    if (result.isError()) {
+        LOG_WARN(Controls, "UserSettingsSet failed: {}", result.errorValue());
+        return;
+    }
+
+    if (result.value().isError()) {
+        LOG_WARN(Controls, "UserSettingsSet error: {}", result.value().errorValue().message);
+        return;
+    }
+
+    eventSink_.queueEvent(UserSettingsUpdatedEvent{ .settings = result.value().value().settings });
+}
+
+void StartMenuSettingsPanel::sendSettingsReset()
+{
+    if (!wsService_ || !wsService_->isConnected()) {
+        LOG_WARN(Controls, "StartMenuSettingsPanel: Cannot reset settings, server disconnected");
+        return;
+    }
+
+    Api::UserSettingsReset::Command cmd{};
+    const auto result =
+        wsService_->sendCommandAndGetResponse<Api::UserSettingsReset::Okay>(cmd, 1000);
+    if (result.isError()) {
+        LOG_WARN(Controls, "UserSettingsReset failed: {}", result.errorValue());
+        return;
+    }
+
+    if (result.value().isError()) {
+        LOG_WARN(Controls, "UserSettingsReset error: {}", result.value().errorValue().message);
+        return;
+    }
+
+    eventSink_.queueEvent(UserSettingsUpdatedEvent{ .settings = result.value().value().settings });
+}
+
+void StartMenuSettingsPanel::updateDefaultScenarioButtonText()
+{
+    std::string scenarioName = toString(settings_.defaultScenario);
+    const auto info = ScenarioMetadataCache::getScenarioInfo(settings_.defaultScenario);
+    if (info.has_value()) {
+        scenarioName = info->name;
+    }
+
+    setActionButtonText(defaultScenarioButton_, "Default Scenario: " + scenarioName);
+}
+
+void StartMenuSettingsPanel::updateResetButtonEnabled()
+{
+    const bool confirmed =
+        resetConfirmCheckbox_ && lv_obj_has_state(resetConfirmCheckbox_, LV_STATE_CHECKED);
+    setControlEnabled(resetButton_, confirmed);
+}
+
+void StartMenuSettingsPanel::updateTimezoneButtonText()
+{
+    const int maxIndex = static_cast<int>(ClockScenario::TIMEZONES.size()) - 1;
+    const int clampedIndex = std::clamp(settings_.timezoneIndex, 0, maxIndex);
+    const char* label = ClockScenario::TIMEZONES[clampedIndex].label;
+    setActionButtonText(timezoneButton_, std::string("Timezone: ") + label);
+}
+
+void StartMenuSettingsPanel::onBackToMainClicked(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->viewController_) {
+        return;
+    }
+
+    self->viewController_->showView("main");
+}
+
+void StartMenuSettingsPanel::onDefaultScenarioButtonClicked(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->viewController_) {
+        return;
+    }
+
+    self->viewController_->showView("scenario");
+}
+
+void StartMenuSettingsPanel::onDefaultScenarioSelected(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    lv_obj_t* button = static_cast<lv_obj_t*>(lv_event_get_target(e));
+    auto it = self->buttonToScenarioIndex_.find(button);
+    if (it == self->buttonToScenarioIndex_.end()) {
+        LOG_WARN(Controls, "StartMenuSettingsPanel: Unknown scenario button clicked");
+        return;
+    }
+
+    self->settings_.defaultScenario =
+        ScenarioMetadataCache::scenarioIdFromIndex(static_cast<uint16_t>(it->second));
+    self->updateDefaultScenarioButtonText();
+
+    if (self->viewController_) {
+        self->viewController_->showView("main");
+    }
+
+    self->sendSettingsUpdate();
+}
+
+void StartMenuSettingsPanel::onResetConfirmToggled(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    self->updateResetButtonEnabled();
+}
+
+void StartMenuSettingsPanel::onResetClicked(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->resetConfirmCheckbox_) {
+        return;
+    }
+
+    if (!lv_obj_has_state(self->resetConfirmCheckbox_, LV_STATE_CHECKED)) {
+        return;
+    }
+
+    self->sendSettingsReset();
+}
+
+void StartMenuSettingsPanel::onTimezoneButtonClicked(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->viewController_) {
+        return;
+    }
+
+    self->viewController_->showView("timezone");
+}
+
+void StartMenuSettingsPanel::onTimezoneSelected(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self) {
+        return;
+    }
+
+    lv_obj_t* button = static_cast<lv_obj_t*>(lv_event_get_target(e));
+    auto it = self->buttonToTimezoneIndex_.find(button);
+    if (it == self->buttonToTimezoneIndex_.end()) {
+        LOG_WARN(Controls, "StartMenuSettingsPanel: Unknown timezone button clicked");
+        return;
+    }
+
+    self->settings_.timezoneIndex = it->second;
+    self->updateTimezoneButtonText();
+
+    if (self->viewController_) {
+        self->viewController_->showView("main");
+    }
+
+    self->sendSettingsUpdate();
+}
+
+void StartMenuSettingsPanel::onVolumeChanged(lv_event_t* e)
+{
+    auto* self = static_cast<StartMenuSettingsPanel*>(lv_event_get_user_data(e));
+    if (!self || !self->volumeStepper_) {
+        return;
+    }
+
+    if (self->updatingUi_) {
+        return;
+    }
+
+    const int value = LVGLBuilder::ActionStepperBuilder::getValue(self->volumeStepper_);
+    self->settings_.volumePercent = std::clamp(value, 0, 100);
+    self->sendSettingsUpdate();
+}
+
+} // namespace Ui
+} // namespace DirtSim

--- a/apps/src/ui/controls/StartMenuSettingsPanel.h
+++ b/apps/src/ui/controls/StartMenuSettingsPanel.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "server/UserSettings.h"
+#include <lvgl/lvgl.h>
+#include <memory>
+#include <unordered_map>
+
+namespace DirtSim {
+namespace Network {
+class WebSocketServiceInterface;
+} // namespace Network
+
+namespace Ui {
+
+class EventSink;
+class PanelViewController;
+
+class StartMenuSettingsPanel {
+public:
+    StartMenuSettingsPanel(
+        lv_obj_t* container, Network::WebSocketServiceInterface* wsService, EventSink& eventSink);
+    ~StartMenuSettingsPanel();
+
+    void applySettings(const DirtSim::UserSettings& settings);
+    void refreshFromServer();
+
+private:
+    void createMainView(lv_obj_t* view);
+    void createScenarioSelectionView(lv_obj_t* view);
+    void createTimezoneSelectionView(lv_obj_t* view);
+
+    void sendSettingsUpdate();
+    void sendSettingsReset();
+
+    void updateDefaultScenarioButtonText();
+    void updateResetButtonEnabled();
+    void updateTimezoneButtonText();
+
+    static void onBackToMainClicked(lv_event_t* e);
+    static void onDefaultScenarioButtonClicked(lv_event_t* e);
+    static void onDefaultScenarioSelected(lv_event_t* e);
+    static void onResetConfirmToggled(lv_event_t* e);
+    static void onResetClicked(lv_event_t* e);
+    static void onTimezoneButtonClicked(lv_event_t* e);
+    static void onTimezoneSelected(lv_event_t* e);
+    static void onVolumeChanged(lv_event_t* e);
+
+    lv_obj_t* container_ = nullptr;
+    lv_obj_t* defaultScenarioButton_ = nullptr;
+    lv_obj_t* resetButton_ = nullptr;
+    lv_obj_t* resetConfirmCheckbox_ = nullptr;
+    lv_obj_t* timezoneButton_ = nullptr;
+    lv_obj_t* volumeStepper_ = nullptr;
+    Network::WebSocketServiceInterface* wsService_ = nullptr;
+    EventSink& eventSink_;
+    std::unordered_map<lv_obj_t*, int> buttonToScenarioIndex_;
+    std::unordered_map<lv_obj_t*, int> buttonToTimezoneIndex_;
+    std::unique_ptr<PanelViewController> viewController_;
+    DirtSim::UserSettings settings_{};
+    bool updatingUi_ = false;
+};
+
+} // namespace Ui
+} // namespace DirtSim

--- a/apps/src/ui/state-machine/Event.h
+++ b/apps/src/ui/state-machine/Event.h
@@ -36,6 +36,7 @@
 #include "core/organisms/evolution/EvolutionConfig.h"
 #include "core/organisms/evolution/GenomeMetadata.h"
 #include "core/organisms/evolution/TrainingSpec.h"
+#include "server/UserSettings.h"
 #include "server/api/EvolutionProgress.h"
 #include "server/api/TrainingBestSnapshot.h"
 #include "server/api/TrainingResult.h"
@@ -236,6 +237,11 @@ struct TrainingBestSnapshotReceivedEvent {
     static constexpr const char* name() { return "TrainingBestSnapshotReceivedEvent"; }
 };
 
+struct UserSettingsUpdatedEvent {
+    DirtSim::UserSettings settings;
+    static constexpr const char* name() { return "UserSettingsUpdatedEvent"; }
+};
+
 // =================================================================
 // UI CONTROL EVENTS
 // =================================================================
@@ -300,6 +306,7 @@ using Event = std::variant<
     // Server data updates
     DirtSim::UiUpdateEvent,
     EvolutionProgressReceivedEvent,
+    UserSettingsUpdatedEvent,
     TrainingBestSnapshotReceivedEvent,
     PhysicsSettingsReceivedEvent,
 

--- a/apps/src/ui/state-machine/StateMachine.h
+++ b/apps/src/ui/state-machine/StateMachine.h
@@ -7,6 +7,7 @@
 #include "core/StateMachineInterface.h"
 #include "core/SystemMetrics.h"
 #include "core/Timers.h"
+#include "server/UserSettings.h"
 #include "states/State.h"
 #include "ui/UiConfig.h"
 #include "ui/UserSettingsManager.h"
@@ -98,6 +99,7 @@ public:
 
     UserSettings& getUserSettings() { return userSettingsManager_->get(); }
     const UserSettings& getUserSettings() const { return userSettingsManager_->get(); }
+    const DirtSim::UserSettings& getServerUserSettings() const { return serverUserSettings_; }
     int getSynthVolumePercent() const { return synthVolumePercent_; }
     void setSynthVolumePercent(int value) { synthVolumePercent_ = std::clamp(value, 0, 100); }
 
@@ -126,11 +128,15 @@ private:
     uint16_t wsPort_ = 7070;
     uint32_t lastInactiveMs_ = 0;
     UserSettingsManager* userSettingsManager_ = nullptr;
+    DirtSim::UserSettings serverUserSettings_{};
     bool startMenuIdleClockTriggered_ = false;
-    int synthVolumePercent_ = 50;
+    int synthVolumePercent_ = 20;
+    bool audioVolumeWarningLogged_ = false;
 
     bool isAutoShrinkBlocked() const;
     void autoShrinkIfIdle();
+    void applyServerUserSettings(const DirtSim::UserSettings& settings);
+    void syncAudioMasterVolume(int volumePercent);
 
     void transitionTo(State::Any newState);
 };

--- a/apps/src/ui/state-machine/states/Disconnected.cpp
+++ b/apps/src/ui/state-machine/states/Disconnected.cpp
@@ -12,6 +12,7 @@
 #include "core/network/WebSocketService.h"
 #include "server/api/EvolutionProgress.h"
 #include "server/api/TrainingBestSnapshot.h"
+#include "server/api/UserSettingsUpdated.h"
 #include "ui/UiComponentManager.h"
 #include "ui/controls/LogPanel.h"
 #include "ui/state-machine/StateMachine.h"
@@ -274,6 +275,17 @@ State::Any Disconnected::onEvent(const ConnectToServerCommand& cmd, StateMachine
                 }
                 catch (const std::exception& e) {
                     LOG_ERROR(Network, "Failed to deserialize TrainingBestSnapshot: {}", e.what());
+                }
+            }
+            else if (messageType == Api::UserSettingsUpdated::name()) {
+                try {
+                    auto settingsUpdate =
+                        DirtSim::Network::deserialize_payload<Api::UserSettingsUpdated>(payload);
+                    sm.queueEvent(
+                        UserSettingsUpdatedEvent{ .settings = std::move(settingsUpdate.settings) });
+                }
+                catch (const std::exception& e) {
+                    LOG_ERROR(Network, "Failed to deserialize UserSettingsUpdated: {}", e.what());
                 }
             }
             else {

--- a/apps/src/ui/state-machine/states/StartMenu.cpp
+++ b/apps/src/ui/state-machine/states/StartMenu.cpp
@@ -70,10 +70,17 @@ void StartMenu::onEnter(StateMachine& sm)
     // Configure IconRail to show StartMenu icons in two columns.
     if (IconRail* iconRail = uiManager->getIconRail()) {
         iconRail->setVisibleIcons(
-            { IconId::CORE, IconId::MUSIC, IconId::EVOLUTION, IconId::NETWORK, IconId::SCENARIO });
+            { IconId::CORE,
+              IconId::SETTINGS,
+              IconId::MUSIC,
+              IconId::EVOLUTION,
+              IconId::NETWORK,
+              IconId::SCENARIO });
         iconRail->setLayout(RailLayout::TwoColumn);
         iconRail->deselectAll();
-        LOG_INFO(State, "Configured IconRail with CORE, MUSIC, EVOLUTION, NETWORK, SCENARIO icons");
+        LOG_INFO(
+            State,
+            "Configured IconRail with CORE, SETTINGS, MUSIC, EVOLUTION, NETWORK, SCENARIO icons");
     }
 
     // Get display dimensions for full-screen fractal.
@@ -150,6 +157,7 @@ void StartMenu::onExit(StateMachine& sm)
 
     // Clean up panels.
     corePanel_.reset();
+    settingsPanel_.reset();
 
     // Clean up sparkle button.
     startButton_.reset();
@@ -283,6 +291,17 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
 
     auto* uiManager = sm.getUiComponentManager();
 
+    if (evt.previousId == IconId::CORE || evt.previousId == IconId::SETTINGS) {
+        LOG_INFO(State, "Panel icon deselected, hiding panel");
+        if (auto* panel = uiManager->getExpandablePanel()) {
+            panel->hide();
+            panel->clearContent();
+            panel->resetWidth();
+        }
+        corePanel_.reset();
+        settingsPanel_.reset();
+    }
+
     // Handle CORE icon - opens core panel with quit button.
     if (evt.selectedId == IconId::CORE) {
         LOG_INFO(State, "Core icon selected, showing core panel");
@@ -296,15 +315,18 @@ State::Any StartMenu::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
         return std::move(*this); // Don't deselect - panel should stay open.
     }
 
-    // Handle deselection of CORE.
-    if (evt.previousId == IconId::CORE) {
-        LOG_INFO(State, "Core icon deselected, hiding panel");
+    if (evt.selectedId == IconId::SETTINGS) {
+        LOG_INFO(State, "Settings icon selected, showing settings panel");
+
         if (auto* panel = uiManager->getExpandablePanel()) {
-            panel->hide();
             panel->clearContent();
             panel->resetWidth();
+            settingsPanel_ = std::make_unique<StartMenuSettingsPanel>(
+                panel->getContentArea(), &sm.getWebSocketService(), sm);
+            settingsPanel_->refreshFromServer();
+            panel->show();
         }
-        corePanel_.reset();
+        return std::move(*this); // Don't deselect - panel should stay open.
     }
 
     if (evt.selectedId == IconId::MUSIC) {
@@ -373,6 +395,15 @@ State::Any StartMenu::onEvent(const TrainButtonClickedEvent& /*evt*/, StateMachi
     LOG_INFO(State, "Train button clicked, transitioning to Training");
 
     return TrainingIdle{};
+}
+
+State::Any StartMenu::onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& /*sm*/)
+{
+    if (settingsPanel_) {
+        settingsPanel_->applySettings(evt.settings);
+    }
+
+    return std::move(*this);
 }
 
 State::Any StartMenu::onEvent(const NextFractalClickedEvent& /*evt*/, StateMachine& /*sm*/)

--- a/apps/src/ui/state-machine/states/StartMenu.h
+++ b/apps/src/ui/state-machine/states/StartMenu.h
@@ -4,6 +4,7 @@
 #include "core/ScenarioId.h"
 #include "ui/controls/SparklingDuckButton.h"
 #include "ui/controls/StartMenuCorePanel.h"
+#include "ui/controls/StartMenuSettingsPanel.h"
 #include "ui/state-machine/Event.h"
 #include <lvgl/lvgl.h>
 #include <memory>
@@ -29,6 +30,7 @@ struct StartMenu {
     Any onEvent(const StartButtonClickedEvent& evt, StateMachine& sm);
     Any onEvent(const StartMenuIdleTimeoutEvent& evt, StateMachine& sm);
     Any onEvent(const TrainButtonClickedEvent& evt, StateMachine& sm);
+    Any onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& sm);
     Any onEvent(const NextFractalClickedEvent& evt, StateMachine& sm);
     Any onEvent(const UiApi::Exit::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::SimRun::Cwc& cwc, StateMachine& sm);
@@ -51,11 +53,12 @@ private:
     StateMachine* sm_ = nullptr;                       // State machine reference for callbacks.
     std::unique_ptr<SparklingDuckButton> startButton_; // Animated start button.
     std::unique_ptr<StartMenuCorePanel> corePanel_;    // Core controls panel (quit, etc.).
-    lv_obj_t* touchDebugLabel_ = nullptr;              // Touch coordinate debug display.
-    lv_obj_t* infoPanel_ = nullptr;                    // Bottom-left info panel container.
-    lv_obj_t* infoLabel_ = nullptr;                    // Fractal info label.
-    int updateFrameCount_ = 0;                         // Frame counter for periodic logging.
-    int labelUpdateCounter_ = 0;                       // Frame counter for label updates (~1/sec).
+    std::unique_ptr<StartMenuSettingsPanel> settingsPanel_; // Settings controls panel.
+    lv_obj_t* touchDebugLabel_ = nullptr;                   // Touch coordinate debug display.
+    lv_obj_t* infoPanel_ = nullptr;                         // Bottom-left info panel container.
+    lv_obj_t* infoLabel_ = nullptr;                         // Fractal info label.
+    int updateFrameCount_ = 0;                              // Frame counter for periodic logging.
+    int labelUpdateCounter_ = 0; // Frame counter for label updates (~1/sec).
 };
 
 } // namespace State

--- a/apps/src/ui/state-machine/states/Synth.cpp
+++ b/apps/src/ui/state-machine/states/Synth.cpp
@@ -127,6 +127,13 @@ State::Any Synth::onEvent(const StopButtonClickedEvent& /*evt*/, StateMachine& /
     return StartMenu{};
 }
 
+State::Any Synth::onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& sm)
+{
+    keyboard_.setVolumePercent(evt.settings.volumePercent);
+    sm.setSynthVolumePercent(evt.settings.volumePercent);
+    return std::move(*this);
+}
+
 State::Any Synth::onEvent(const ServerDisconnectedEvent& evt, StateMachine& sm)
 {
     LOG_WARN(State, "Server disconnected (reason: {})", evt.reason);

--- a/apps/src/ui/state-machine/states/Synth.h
+++ b/apps/src/ui/state-machine/states/Synth.h
@@ -24,6 +24,7 @@ struct Synth {
     Any onEvent(const RailModeChangedEvent& evt, StateMachine& sm);
     Any onEvent(const ServerDisconnectedEvent& evt, StateMachine& sm);
     Any onEvent(const StopButtonClickedEvent& evt, StateMachine& sm);
+    Any onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& sm);
     Any onEvent(const UiApi::Exit::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::SimStop::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::StopButtonPress::Cwc& cwc, StateMachine& sm);

--- a/apps/src/ui/state-machine/states/SynthConfig.cpp
+++ b/apps/src/ui/state-machine/states/SynthConfig.cpp
@@ -156,6 +156,19 @@ State::Any SynthConfig::onEvent(const StopButtonClickedEvent& /*evt*/, StateMach
     return StartMenu{};
 }
 
+State::Any SynthConfig::onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& sm)
+{
+    volumePercent_ = std::clamp(evt.settings.volumePercent, 0, 100);
+    keyboard_.setVolumePercent(volumePercent_);
+    sm.setSynthVolumePercent(volumePercent_);
+
+    if (volumeStepper_) {
+        LVGLBuilder::ActionStepperBuilder::setValue(volumeStepper_, volumePercent_);
+    }
+
+    return std::move(*this);
+}
+
 State::Any SynthConfig::onEvent(const ServerDisconnectedEvent& evt, StateMachine& sm)
 {
     LOG_WARN(State, "Server disconnected (reason: {})", evt.reason);

--- a/apps/src/ui/state-machine/states/SynthConfig.h
+++ b/apps/src/ui/state-machine/states/SynthConfig.h
@@ -18,6 +18,7 @@ struct SynthConfig {
     Any onEvent(const RailModeChangedEvent& evt, StateMachine& sm);
     Any onEvent(const ServerDisconnectedEvent& evt, StateMachine& sm);
     Any onEvent(const StopButtonClickedEvent& evt, StateMachine& sm);
+    Any onEvent(const UserSettingsUpdatedEvent& evt, StateMachine& sm);
     Any onEvent(const UiApi::Exit::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::SimStop::Cwc& cwc, StateMachine& sm);
     Any onEvent(const UiApi::StopButtonPress::Cwc& cwc, StateMachine& sm);

--- a/apps/src/ui/state-machine/states/Training.cpp
+++ b/apps/src/ui/state-machine/states/Training.cpp
@@ -351,6 +351,7 @@ State::Any TrainingIdle::onEvent(const IconSelectedEvent& evt, StateMachine& sm)
         case IconId::PHYSICS:
         case IconId::PLAY:
         case IconId::SCENARIO:
+        case IconId::SETTINGS:
         case IconId::NONE:
             DIRTSIM_ASSERT(false, "Unexpected icon selection in Training idle");
             break;


### PR DESCRIPTION
## Summary
- Add `UserSettings` persistent storage with get/set/reset API commands and broadcast notifications
- Add `StartMenuSettingsPanel` UI with master volume slider and idle clock timeout toggle
- Wire master volume setting through to `AudioEngine` so it applies on startup and on change
- Add `FunctionalTestRunner` CLI for exercising UI/server workflows via WebSocket
- Add unit tests for `UserSettings` and `StateIdle` settings integration

## Test plan
- [ ] Verify settings panel opens from start menu icon rail
- [ ] Adjust master volume slider and confirm audio level changes
- [ ] Toggle idle clock timeout and confirm behavior in idle state
- [ ] Reset settings and confirm defaults restore
- [ ] Run `dirtsim-tests` — new `UserSettings_test` and `StateIdle_test` cases pass
- [ ] Run functional tests via CLI